### PR TITLE
adds option to override the baseUri for the generated pagination links

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -21,6 +21,7 @@ const internals = {
             invalid: 'defaults'
         },
         meta: {
+            baseUri: '',            
             name: 'meta',
             count: {
                 active: true,
@@ -105,6 +106,7 @@ internals.schema = Joi.object({
         invalid: Joi.string().required()
     }),
     meta: Joi.object({
+        baseUri: Joi.string().allow(''),
         name: Joi.string().required(),
         count: internals.metaParameter,
         totalCount: internals.metaParameter,

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ exports.register = function (server, options, next) {
 
     const config = results.value;
 
-    config.uri   = server.info.uri;
+    config.uri   = config.meta.baseUri || server.info.uri;
 
     const decorate = require('./decorate')(config);
     const ext      = require('./ext')(config);

--- a/test/test.js
+++ b/test/test.js
@@ -482,6 +482,53 @@ describe('Override default values', () => {
             });
         });
     });
+
+
+    it('use custom baseUri instead of server provided uri', (done) => {
+        const myCustomUri = 'https://127.0.0.1:81';
+       const options = {
+            meta: {
+                baseUri: myCustomUri,
+                name: 'meta',
+                count: {
+                    active: true
+                },
+                totalCount: {
+                    active: true
+                },
+                pageCount: {
+                    active: true
+                },
+                self: {
+                    active: true
+                },
+                first: {
+                    active: true
+                }
+            }
+        };
+        const server = register();
+        server.register({
+            register: require(pluginName),
+            options: options
+        }, (err) => {
+
+            expect(err).to.be.undefined();
+
+            server.inject({
+                method: 'GET',
+                url: '/'
+            }, (res) => {
+
+                const response = res.request.response.source;
+                const meta = response.meta;
+                expect(meta.first).to.include(myCustomUri);
+                expect(meta.self).to.include(myCustomUri);
+                done();
+            });
+        });
+    });
+
 });
 
 describe('Override default values for / route', () => {


### PR DESCRIPTION
Hi,

I've added an option to override the base uri (protocol + server + port) to use in the generated links. This allows for the use of this plugin in a typical production environment where an API might live behind a load balancer that offloads SSL/TLS and where some port mapping might happen. 

I like this plugin, including this feature would be awesome.
