### PR TITLE
Path regex support

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -21,7 +21,7 @@ const internals = {
             invalid: 'defaults'
         },
         meta: {
-            baseUri: '',            
+            baseUri: '',
             name: 'meta',
             count: {
                 active: true,
@@ -130,8 +130,8 @@ internals.schema = Joi.object({
         paginate: Joi.string().required()
     }),
     routes: Joi.object({
-        include: Joi.array().items(Joi.string()), // May register no routes...
-        exclude: Joi.array().items(Joi.string()),
+        include: Joi.array().items(Joi.alternatives().try(Joi.object(), Joi.string())), // May register no routes...
+        exclude: Joi.array().items(Joi.alternatives().try(Joi.object(), Joi.string())),
         override: Joi.array().items(Joi.object({
             routes: Joi.array().items(Joi.string()),
             limit: Joi.number().integer(),

--- a/lib/config.js
+++ b/lib/config.js
@@ -130,8 +130,8 @@ internals.schema = Joi.object({
         paginate: Joi.string().required()
     }),
     routes: Joi.object({
-        include: Joi.array().items(Joi.alternatives().try(Joi.object(), Joi.string())), // May register no routes...
-        exclude: Joi.array().items(Joi.alternatives().try(Joi.object(), Joi.string())),
+        include: Joi.array().items(Joi.alternatives().try(Joi.object().type(RegExp), Joi.string())), // May register no routes...
+        exclude: Joi.array().items(Joi.alternatives().try(Joi.object().type(RegExp), Joi.string())),
         override: Joi.array().items(Joi.object({
             routes: Joi.array().items(Joi.string()),
             limit: Joi.number().integer(),

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -13,10 +13,9 @@ const internals = {
         const path    = request.route.path;
         const method  = request.route.method;
 
-
         return (method === 'get' &&
-               (include[0] === '*' ||  _.includes(include, path)) &&
-               !_.includes(exclude, path));
+               (include[0] === '*' ||  containsPath(include, path)) &&
+               !containsPath(exclude, path));
     },
     getPagination: function (request, config) {
         let pagination = request.query[config.query.pagination.name];
@@ -39,6 +38,15 @@ const internals = {
             meta[this.name(name)] = value;
         }
     }
+};
+
+var containsPath = (array, path) => {
+    return _.any(array, (item => {
+        if (item instanceof RegExp) {
+            return item.test(path);
+        }
+        return item === path;
+    }));
 };
 
 

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -41,12 +41,12 @@ const internals = {
 };
 
 var containsPath = (array, path) => {
-    return _.any(array, (item => {
+    return _.any(array, (item) => {
         if (item instanceof RegExp) {
             return item.test(path);
         }
         return item === path;
-    }));
+    });
 };
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -215,6 +215,90 @@ describe('Override default values', () => {
 
     });
 
+    it('Override defaults routes with regex in include', (done) => {
+        const options = {
+            routes: {
+                include: [/^\/u.*s$/]
+            }
+        };
+        const server = register();
+        server.register({
+            register: require(pluginName),
+            options: options
+        }, (err) => {
+
+            expect(err).to.be.undefined();
+
+            server.inject({
+                method: 'GET',
+                url: '/users'
+            }, (res) => {
+
+                const query = res.request.query;
+                expect(query.limit).to.equal(25);
+                expect(query.page).to.equal(1);
+
+                done();
+            });
+        });
+    });
+
+    it('Override defaults routes with both regex and string in include', (done) => {
+        const options = {
+            routes: {
+                include: [/^\/hello$/, "/users"]
+            }
+        };
+        const server = register();
+        server.register({
+            register: require(pluginName),
+            options: options
+        }, (err) => {
+
+            expect(err).to.be.undefined();
+
+            server.inject({
+                method: 'GET',
+                url: '/users'
+            }, (res) => {
+
+                const query = res.request.query;
+                expect(query.limit).to.equal(25);
+                expect(query.page).to.equal(1);
+
+                done();
+            });
+        });
+    });
+
+    it('Override defaults routes with regex in include without a match', (done) => {
+        const options = {
+            routes: {
+                include: [/^\/hello.*$/]
+            }
+        };
+        const server = register();
+        server.register({
+            register: require(pluginName),
+            options: options
+        }, (err) => {
+
+            expect(err).to.be.undefined();
+
+            server.inject({
+                method: 'GET',
+                url: '/users'
+            }, (res) => {
+
+                const query = res.request.query;
+                expect(query.limit).to.be.undefined();
+                expect(query.page).to.be.undefined();
+
+                done();
+            });
+        });
+    });
+
     it('Override defaults routes with exclude', (done) => {
         const options = {
             routes: {
@@ -245,7 +329,7 @@ describe('Override default values', () => {
 
     });
 
-    it('Override defaults routes with exclude', (done) => {
+    it('Override defaults routes with exclude 2', (done) => {
         const options = {
             routes: {
                 include: ['/users'],
@@ -268,6 +352,90 @@ describe('Override default values', () => {
                 const query = res.request.query;
                 expect(query.limit).to.be.undefined();
                 expect(query.page).to.be.undefined();
+
+                done();
+            });
+        });
+    });
+
+    it('Override defaults routes with regex in exclude', (done) => {
+        const options = {
+            routes: {
+                include: ['*'],
+                exclude: [/^\/.*/]
+            }
+        };
+        const server = register();
+        server.register({
+            register: require(pluginName),
+            options: options
+        }, (err) => {
+            expect(err).to.be.undefined();
+
+            server.inject({
+                method: 'GET',
+                url: '/'
+            }, (res) => {
+
+                const query = res.request.query;
+                expect(query.limit).to.be.undefined();
+                expect(query.page).to.be.undefined();
+
+                done();
+            });
+        });
+    });
+
+    it('Override defaults routes with both regex and string in exclude', (done) => {
+        const options = {
+            routes: {
+                include: ['*'],
+                exclude: [/^nothing/, "/"]
+            }
+        };
+        const server = register();
+        server.register({
+            register: require(pluginName),
+            options: options
+        }, (err) => {
+            expect(err).to.be.undefined();
+
+            server.inject({
+                method: 'GET',
+                url: '/'
+            }, (res) => {
+
+                const query = res.request.query;
+                expect(query.limit).to.be.undefined();
+                expect(query.page).to.be.undefined();
+
+                done();
+            });
+        });
+    });
+
+    it('Override defaults routes with regex without a match', (done) => {
+        const options = {
+            routes: {
+                include: ['*'],
+                exclude: [/^nothing/]
+            }
+        };
+        const server = register();
+        server.register({
+            register: require(pluginName),
+            options: options
+        }, (err) => {
+            expect(err).to.be.undefined();
+
+            server.inject({
+                method: 'GET',
+                url: '/'
+            }, (res) => {
+
+                const query = res.request.query;
+                expect(query.limit).to.equal(25);
+                expect(query.page).to.equal(1);
 
                 done();
             });


### PR DESCRIPTION
Adding support to use a regex in the include and exclude array.

Useful for paths like /v1/users.
