### PR TITLE
Added a custom route option to override whether pagination is on or off

### DIFF
--- a/lib/ext.js
+++ b/lib/ext.js
@@ -8,11 +8,14 @@ const Qs   = require('qs');
 const internals = {
     isValidRoute: function (request) {
 
+        const customRouteOptions = request.route.settings.plugins.pagination || {};
         const include = this.config.routes.include;
         const exclude = this.config.routes.exclude;
         const path    = request.route.path;
         const method  = request.route.method;
 
+        if (customRouteOptions.enabled === false) return false;
+        else if (customRouteOptions.enabled === true) return true;
 
         return (method === 'get' &&
                (include[0] === '*' ||  _.includes(include, path)) &&

--- a/test/test.js
+++ b/test/test.js
@@ -47,6 +47,28 @@ const register = () => {
     });
 
     server.route({
+        method: 'GET',
+        path: '/enabled',
+        config: {
+            plugins: {
+                pagination: { enabled: true }
+            },
+            handler: (request, reply) => reply([])
+        }
+    });
+
+    server.route({
+        method: 'GET',
+        path: '/disabled',
+        config: {
+            plugins: {
+                pagination: { enabled: false }
+            },
+            handler: (request, reply) => reply([])
+        }
+    });
+
+    server.route({
         method: 'POST',
         path: '/users',
         handler: (request, reply) => {
@@ -470,6 +492,66 @@ describe('Override default values', () => {
         });
     });
 
+});
+
+describe('Custom route options', () => {
+    it('Force a route to include pagination', (done) => {
+        const options = {
+            routes: {
+                exclude: ['/enabled']
+            }
+        };
+        const server = register();
+        server.register({
+            register: require(pluginName),
+            options: options
+        }, (err) => {
+
+            expect(err).to.be.undefined();
+
+            server.inject({
+                method: 'GET',
+                url: '/enabled'
+            }, (res) => {
+
+                const query = res.request.query;
+                expect(query.limit).to.equal(25);
+                expect(query.page).to.equal(1);
+
+                done();
+            });
+        });
+    });
+
+    it('Force a route to exclude pagination', (done) => {
+        const options = {
+            routes: {
+                include: ['/disabled']
+            }
+        };
+        const server = register();
+        server.register({
+            register: require(pluginName),
+            options: options
+        }, (err) => {
+
+            expect(err).to.be.undefined();
+
+            server.inject({
+                method: 'GET',
+                url: '/disabled'
+            }, (res) => {
+
+                const query = res.request.query;
+                expect(query.limit).to.be.undefined();
+                expect(query.page).to.be.undefined();
+
+                done();
+            });
+        });
+
+
+    });
 });
 
 describe('Override default values for / route', () => {


### PR DESCRIPTION
This allows you to configure if pagination is applied at the route definition using the hapi plugin options.

E.g.
    config: {
        plugins: {
            pagination: { enabled: true }
        },
        handler: (request, reply) => reply([])
    }

This overrides the global include/exclude array settings, and allows us not to care about actual paths.
