### PR TITLE
Put metadata in http headers rather than in body

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,21 @@ Notes:
 
 #### The metadata
 
-The plugin will generate a metadata object alongside your resources, you can
-customize this object with the following options:
+By default the plugin will generate a metadata object alongside your resources in the response body.
+You can also decide to put the metadata in the response header, so the body remains clean.
+In this case, the plugin will use 2 kinds of headers:
+* `Content-Range`: `startIndex-endIndex/totalCount` (see https://tools.ietf.org/html/rfc7233#section-4.2)
+  This header gives the start and end indexes of the current page records, followed by the total number of records.
+* `Link`: `<url>; rel=relationship` (see https://tools.ietf.org/html/rfc2068#section-19.6.2.4)
+  This header gives the url to different resources related to the current page. The available relationships are :
+    + `rel=self`: the current page
+    + `rel=first`: the first page
+    + `rel=prev`: the previous page
+    + `rel=next`: the next page
+    + `rel=last`: the last page
+
+To choose where the metadata will be put, use the option meta.location (see below).
+You can customize the metadata with the following options:
 
 
 * `name`: The name of the metadata object. Default is 'meta'.
@@ -85,10 +98,11 @@ customize this object with the following options:
 * `last`: Same than previous but with last page.
 * `page`: The page number requested. Default name is page, disabled by default.
 * `limit`: The limit requested. Default name is limit, disabled by default.
+* `location`: 'body' put the metadata in the response body, 'header' put the metadata in the response header. Default is 'body'.
 
 #### The results
 
-* `name`: the name of the results array, results by default.
+* `name`: the name of the results array, results by default. Useful with location='body' only.
 * `reply`: Object with:
     + `paginate`: The name of the paginate method (see below), paginate by
     default.
@@ -96,7 +110,7 @@ customize this object with the following options:
 #### The routes
 
 * `include`: An array of routes that you want to include, support \* and regex.
-  Default to '\*'. 
+  Default to '\*'.
 * `exclude`: An array of routes that you want to exclude. Useful when include is
   '\*'. Default to empty array. Support regex.
 
@@ -111,7 +125,7 @@ useful when you're using regex for example.
 config: {
   plugins: {
     pagination: {
-      // enabled: boolean - force enable or force disable 
+      // enabled: boolean - force enable or force disable
       defaults: {
         // page: override page
         // limit: override limit
@@ -161,7 +175,7 @@ return reply.paginate({ results: [], otherKey: 'value', otherKey2: 'value2' }, 0
 ```
 
 The response will also contains `otherKey` and `otherKey2`. Nested keys for the paginated results are not allowed.
- 
+
 If you pass an object but forgot to pass a key for your results, the paginate method will throw an error. Same thing if the key does not exist.
 
 ##### WARNING: If the results is not an array, the program will throw an implementation error.
@@ -198,6 +212,7 @@ const options = {
     },
 
     meta: {
+        location: 'body',
         name: 'meta',
         count: {
             active: true,
@@ -261,7 +276,7 @@ const options = {
           name: 'totalCount'
         }
     },
-    
+
     routes: {
         include: ['*'],
         exclude: []
@@ -305,6 +320,7 @@ const options = {
       }
     },
      meta: {
+        location: 'body', // The metadata will be put in the response body
         name: 'metadata', // The meta object will be called metadata
         count: {
             active: true,
@@ -393,7 +409,7 @@ validate: {
   }
 }
 
-// OR 
+// OR
 
 validate: {
   options: {
@@ -412,4 +428,3 @@ Make sure you have `lab` and `code` installed and run :
 ```
 npm test
 ```
-

--- a/lib/config.js
+++ b/lib/config.js
@@ -37,6 +37,7 @@ internals.schemas.options = Joi.object({
         invalid: Joi.string().required()
     }),
     meta: Joi.object({
+        location: Joi.string().valid('body', 'header'),
         baseUri: Joi.string().allow(''),
         name: Joi.string().required(),
         count: internals.schemas.metaParameter,

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -17,6 +17,7 @@ module.exports = {
         invalid: 'defaults'
     },
     meta: {
+        location: 'body',
         baseUri: '',
         name: 'meta',
         count: {

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -173,38 +173,60 @@ internals.onPreResponse = function (request, reply) {
 
         const meta = {};
 
-        internals.assignIfActive(meta, 'page', query[internals.name('page')]);
-        internals.assignIfActive(meta, 'limit', query[internals.name('limit')]);
-
-        internals.assignIfActive(meta, 'count', results.length);
-        internals.assignIfActive(meta, 'pageCount', pageCount);
-        internals.assignIfActive(meta, 'totalCount', Utils.isNil(totalCount) ? null : totalCount);
-
         const hasNext = !Utils.isNil(totalCount) && totalCount !== 0 && currentPage < pageCount;
         const hasPrevious = !Utils.isNil(totalCount) && totalCount !== 0 && currentPage > 1;
-        internals.assignIfActive(meta, 'next', hasNext ? getUri(currentPage + 1) : null);
-        internals.assignIfActive(meta, 'previous', getUri(currentPage - 1));
-        internals.assignIfActive(meta, 'hasNext',      hasNext);
-        internals.assignIfActive(meta, 'hasPrevious',  hasPrevious);
 
-        internals.assignIfActive(meta, 'self',     getUri(currentPage));
-        internals.assignIfActive(meta, 'first',    getUri(1));
-        internals.assignIfActive(meta, 'last',     getUri(pageCount));
+        if (internals.config.meta.location === 'header') {
+          // put metadata in headers rather than in body
+          let startIndex = currentLimit * (currentPage - 1);
+          let endIndex = startIndex + results.length - 1;
+          request.response.headers['Content-Range'] = `${startIndex}-${endIndex}/${totalCount}`;
+
+          let links = [];
+          links.push(`<${getUri(currentPage)}>; rel=self`);
+          links.push(`<${getUri(1)}>; rel=first`);
+          links.push(`<${getUri(pageCount)}>; rel=last`);
+          if (hasNext) {
+            links.push(`<${getUri(currentPage + 1)}>; rel=next`);
+          }
+          if (hasPrevious) {
+            links.push(`<${getUri(currentPage - 1)}>; rel=prev`);
+          }
+          request.response.headers['Link'] = links;
+
+          request.response.source = results;
+        } else {
+          internals.assignIfActive(meta, 'page', query[internals.name('page')]);
+          internals.assignIfActive(meta, 'limit', query[internals.name('limit')]);
+
+          internals.assignIfActive(meta, 'count', results.length);
+          internals.assignIfActive(meta, 'pageCount', pageCount);
+          internals.assignIfActive(meta, 'totalCount', Utils.isNil(totalCount) ? null : totalCount);
+
+          internals.assignIfActive(meta, 'next', hasNext ? getUri(currentPage + 1) : null);
+          internals.assignIfActive(meta, 'previous', getUri(currentPage - 1));
+          internals.assignIfActive(meta, 'hasNext',      hasNext);
+          internals.assignIfActive(meta, 'hasPrevious',  hasPrevious);
+
+          internals.assignIfActive(meta, 'self',     getUri(currentPage));
+          internals.assignIfActive(meta, 'first',    getUri(1));
+          internals.assignIfActive(meta, 'last',     getUri(pageCount));
 
 
-        request.response.source = {
-            [internals.config.meta.name]: meta,
-            [internals.config.results.name]: results
-        };
+          request.response.source = {
+              [internals.config.meta.name]: meta,
+              [internals.config.results.name]: results
+          };
 
-        if (source.response) {
-            const keys = Object.keys(source.response);
-            keys.forEach((key) => {
-                if (key !== internals.config.meta.name &&
-                    key !== internals.config.results.name) {
-                        request.response.source[key] = source.response[key];
-                    }
-            });
+          if (source.response) {
+              const keys = Object.keys(source.response);
+              keys.forEach((key) => {
+                  if (key !== internals.config.meta.name &&
+                      key !== internals.config.results.name) {
+                          request.response.source[key] = source.response[key];
+                      }
+              });
+          }
         }
     }
 
@@ -221,5 +243,3 @@ module.exports = function (config) {
         onPreResponse: internals.onPreResponse
     };
 };
-
-

--- a/test/test.js
+++ b/test/test.js
@@ -872,6 +872,83 @@ describe('Override default values', () => {
         });
     });
 
+      it('Override meta location - move metadata to http headers with multiple pages', (done) => {
+        const options = {
+          query: {
+            limit: {
+              default: 5
+            },
+            page: {
+              default: 2
+            }
+          },
+          meta: {
+            location: 'header'
+          }
+        };
+
+        const server = register();
+        server.register({
+          register: require(pluginName),
+          options: options
+        }, (err) => {
+          expect(err).to.be.undefined();
+
+          server.inject({
+            method: 'GET',
+            url: '/users'
+          }, (res) => {
+            const headers = res.request.response.headers;
+            const response = res.request.response.source;
+            expect(headers['Content-Range']).to.equal('5-9/20');
+            expect(headers['Link']).to.be.an.array();
+            expect(headers['Link']).to.have.length(5);
+            expect(headers['Link'][0]).match(/rel=self$/);
+            expect(headers['Link'][1]).match(/rel=first$/);
+            expect(headers['Link'][2]).match(/rel=last$/);
+            expect(headers['Link'][3]).match(/rel=next$/);
+            expect(headers['Link'][4]).match(/rel=prev$/);
+            expect(response).to.be.an.array();
+            expect(response).to.have.length(5);
+
+            done();
+          })
+        })
+      })
+
+      it('Override meta location - move metadata to http headers with unique page', (done) => {
+        const options = {
+          meta: {
+            location: 'header'
+          }
+        };
+
+        const server = register();
+        server.register({
+          register: require(pluginName),
+          options: options
+        }, (err) => {
+          expect(err).to.be.undefined();
+
+          server.inject({
+            method: 'GET',
+            url: '/users'
+          }, (res) => {
+            const headers = res.request.response.headers;
+            const response = res.request.response.source;
+            expect(headers['Content-Range']).to.equal('0-19/20');
+            expect(headers['Link']).to.be.an.array();
+            expect(headers['Link']).to.have.length(3);
+            expect(headers['Link'][0]).match(/rel=self$/);
+            expect(headers['Link'][1]).match(/rel=first$/);
+            expect(headers['Link'][2]).match(/rel=last$/);
+            expect(response).to.be.an.array();
+            expect(response).to.have.length(20);
+
+            done();
+          })
+        })
+      })
 
     it('use custom baseUri instead of server provided uri', (done) => {
 
@@ -1985,6 +2062,3 @@ describe('Override on route level error', () => {
         });
     });
 });
-
-
-


### PR DESCRIPTION
Keep payload unchanged and use standard HTTP headers.
Use an option to enable this (disable by default).
