### PR TITLE
Fix response validation when metadata in headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ The response will also contains `otherKey` and `otherKey2`. Nested keys for the 
 
 If you pass an object but forgot to pass a key for your results, the paginate method will throw an error. Same thing if the key does not exist.
 
+Please note that if you pass metadata in headers the custom properties don't work, because we don't want to change the response in this case. 
+
 ##### WARNING: If the results is not an array, the program will throw an implementation error.
 
 If totalCount is not exposed through the request object

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -7,28 +7,31 @@ module.exports = function (config) {
 
   return {
     paginate: function (response, totalCount, options) {
-        
+
       options = options || {};
       const key = options.key;
-      
+
       if (!Array.isArray(response) && !key) {
         throw { message: 'Missing results key', code: 500 };
       }
-      
+
       if (key && !response[key]) {
-        throw { message: 'key: ' + key + 'does not exists on response', code: 500 }; 
+        throw { message: 'key: ' + key + 'does not exists on response', code: 500 };
       }
-      
+
       const results = (key && !Array.isArray(response)) ? response[key] : response;
-      
+
       if (key && !Array.isArray(response)) {
         delete response[key];
       }
-      
-      return this.response({ 
-        results: results, 
+
+      if (config.meta.location === 'header') {
+        return this.response(results).header('total-count', totalCount);
+      }
+      return this.response({
+        results: results,
         totalCount: totalCount,
-        response: Array.isArray(response) ? null : response 
+        response: Array.isArray(response) ? null : response
       });
     }
   };

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -28,10 +28,11 @@ module.exports = function (config) {
       if (config.meta.location === 'header') {
         return this.response(results).header('total-count', totalCount);
       }
+
       return this.response({
         results: results,
         totalCount: totalCount,
-        response: Array.isArray(response) ? null : response
+        response: Array.isArray(response) ? null : response 
       });
     }
   };

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -143,7 +143,6 @@ internals.onPreResponse = function (request, reply) {
   if (internals.config.query.pagination.default) {
     delete request.query[internals.config.query.pagination.name];
   }
-
   const source = request.response.source;
   const results = Array.isArray(source) ? source : source[internals.config.reply.parameters.results.name];
   Hoek.assert(Array.isArray(results), 'The results must be an array');
@@ -154,7 +153,9 @@ internals.onPreResponse = function (request, reply) {
   const currentLimit = query[internals.config.query.limit.name];
 
   const totalCount = Utils.isUndefined(source[internals.config.reply.parameters.totalCount.name])
-                      ?  request[internals.config.meta.totalCount.name]
+                      ? Utils.isUndefined(request.response.headers['total-count'])
+                        ? request[internals.config.meta.totalCount.name]
+                        : request.response.headers['total-count']
                       : source[internals.config.reply.parameters.totalCount.name];
 
   let pageCount = null;
@@ -177,7 +178,17 @@ internals.onPreResponse = function (request, reply) {
     return baseUri + Qs.stringify(qs);
   };
 
+<<<<<<< 80fbb6f97b68733cf2f062b94fbdd4d23dd75a5e
   const meta = {};
+=======
+        if (internals.config.meta.location === 'header') {
+          delete request.response.headers['total-count']
+
+          // put metadata in headers rather than in body
+          let startIndex = currentLimit * (currentPage - 1);
+          let endIndex = startIndex + results.length - 1;
+          request.response.headers['Content-Range'] = `${startIndex}-${endIndex}/${totalCount}`;
+>>>>>>> Do not change the response in paginate(), pass totalCount in header, so response validation is not impacted
 
   const hasNext = !Utils.isNil(totalCount) && totalCount !== 0 && currentPage < pageCount;
   const hasPrevious = !Utils.isNil(totalCount) && totalCount !== 0 && currentPage > 1;

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -128,8 +128,8 @@ internals.onPreHandler = function (request, reply) {
 };
 
 internals.onPreResponse = function (request, reply) {
-  
-  const processResponse = 
+
+  const processResponse =
       internals.isValidRoute(request) &&
       !request.response.isBoom &&
       internals.getPagination(request, internals.config);
@@ -153,13 +153,13 @@ internals.onPreResponse = function (request, reply) {
   const currentPage  = query[internals.config.query.page.name];
   const currentLimit = query[internals.config.query.limit.name];
 
-  const totalCount = Utils.isUndefined(source[internals.config.reply.parameters.totalCount.name]) 
-                      ?  request[internals.config.meta.totalCount.name] 
+  const totalCount = Utils.isUndefined(source[internals.config.reply.parameters.totalCount.name])
+                      ?  request[internals.config.meta.totalCount.name]
                       : source[internals.config.reply.parameters.totalCount.name];
 
   let pageCount = null;
   if (!Utils.isNil(totalCount)) {
-    pageCount = 
+    pageCount =
       Math.trunc(totalCount / currentLimit) + (totalCount % currentLimit === 0 ? 0 : 1);
   }
 
@@ -183,7 +183,7 @@ internals.onPreResponse = function (request, reply) {
   const hasPrevious = !Utils.isNil(totalCount) && totalCount !== 0 && currentPage > 1;
 
   if (internals.config.meta.location === 'header') {
-    
+
     // put metadata in headers rather than in body
     const startIndex = currentLimit * (currentPage - 1);
     const endIndex = startIndex + results.length - 1;
@@ -204,9 +204,9 @@ internals.onPreResponse = function (request, reply) {
     request.response.headers['Content-Range'] = startIndex + '-' + endIndex + '/' + totalCount;
     request.response.headers['Link'] = links;
     request.response.source = results;
-  } 
+  }
   else {
-    
+
     internals.assignIfActive(meta, 'page',        query[internals.name('page')]);
     internals.assignIfActive(meta, 'limit',       query[internals.name('limit')]);
 

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -143,6 +143,7 @@ internals.onPreResponse = function (request, reply) {
   if (internals.config.query.pagination.default) {
     delete request.query[internals.config.query.pagination.name];
   }
+
   const source = request.response.source;
   const results = Array.isArray(source) ? source : source[internals.config.reply.parameters.results.name];
   Hoek.assert(Array.isArray(results), 'The results must be an array');
@@ -178,22 +179,12 @@ internals.onPreResponse = function (request, reply) {
     return baseUri + Qs.stringify(qs);
   };
 
-<<<<<<< 80fbb6f97b68733cf2f062b94fbdd4d23dd75a5e
   const meta = {};
-=======
-        if (internals.config.meta.location === 'header') {
-          delete request.response.headers['total-count']
-
-          // put metadata in headers rather than in body
-          let startIndex = currentLimit * (currentPage - 1);
-          let endIndex = startIndex + results.length - 1;
-          request.response.headers['Content-Range'] = `${startIndex}-${endIndex}/${totalCount}`;
->>>>>>> Do not change the response in paginate(), pass totalCount in header, so response validation is not impacted
-
   const hasNext = !Utils.isNil(totalCount) && totalCount !== 0 && currentPage < pageCount;
   const hasPrevious = !Utils.isNil(totalCount) && totalCount !== 0 && currentPage > 1;
 
   if (internals.config.meta.location === 'header') {
+    delete request.response.headers['total-count']
 
     // put metadata in headers rather than in body
     const startIndex = currentLimit * (currentPage - 1);


### PR DESCRIPTION
A small fix to keep response body untouch for Joi validation.
Also make clear in Readme that custom properties don't make sense in case of metadata in headers.