### PR TITLE
Set http headers and status code only if partial content

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ these parameters with the following options:
 * `page`: The number of the page that will be returned. Default value is 1,
   default name is page.
 * `pagination`: Allows you to enable, disable pagination for one request. Default
-  value is true (enabled), default name is pagination.
+  value is true (enabled), default name is pagination, enabled by default.
 * `invalid`: This is `NOT` a query parameter, but it allows you to customize the
   behavior if the validation of limit and page fails. By default, it sets the
   defaults, you can set it to 'badRequest' that will send you a `400 - Bad
@@ -210,14 +210,15 @@ const options = {
         },
         pagination: {
             name: 'pagination',
-      default: true
+            default: true,
+            active: true
     }
         invalid: 'defaults'
     },
 
     meta: {
         location: 'body',
-        successStatusCode: 206,
+        successStatusCode: undefined,
         name: 'meta',
         count: {
             active: true,

--- a/lib/config.js
+++ b/lib/config.js
@@ -32,7 +32,8 @@ internals.schemas.options = Joi.object({
     }),
     pagination: Joi.object({
       name: Joi.string().required(),
-      default: Joi.boolean().required()
+      default: Joi.boolean().required(),
+      active: Joi.boolean().required()
     }),
     invalid: Joi.string().required()
   }),

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -12,7 +12,8 @@ module.exports = {
     },
     pagination: {
       name: 'pagination',
-      default: true
+      default: true,
+      active: true
     },
     invalid: 'defaults'
   },

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -42,17 +42,19 @@ internals.isValidRoute = function (request) {
 
 
 internals.getPagination = function (request, config) {
+  if (config.query.pagination.active) {
+    const pagination = request.query[config.query.pagination.name];
+
+    if (pagination === 'false' || pagination === false) {
+      return false;
+    }
+
+    if (pagination === 'true' || pagination === true) {
+      return true;
+    }
+  }
 
   const routeDefaults = internals.getRouteOptions(request).defaults || {};
-  const pagination = request.query[config.query.pagination.name];
-
-  if (pagination === 'false' || pagination === false) {
-    return false;
-  }
-
-  if (pagination === 'true' || pagination === true) {
-    return true;
-  }
 
   if (!Utils.isUndefined(routeDefaults.pagination)) {
     return routeDefaults.pagination;

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -186,29 +186,35 @@ internals.onPreResponse = function (request, reply) {
   if (internals.config.meta.location === 'header') {
     delete request.response.headers['total-count']
 
-    // put metadata in headers rather than in body
-    const startIndex = currentLimit * (currentPage - 1);
-    const endIndex = startIndex + results.length - 1;
+    if (totalCount > currentLimit) {
+      // put metadata in headers rather than in body
+      const startIndex = currentLimit * (currentPage - 1);
+      const endIndex = startIndex + results.length - 1;
 
-    const links = [];
-    links.push('<' + getUri(currentPage) + '>; rel="self"');
-    links.push('<' + getUri(1) + '>; rel="first"');
-    links.push('<' + getUri(pageCount) + '>; rel="last"');
+      const links = [];
+      links.push('<' + getUri(currentPage) + '>; rel="self"');
+      links.push('<' + getUri(1) + '>; rel="first"');
+      links.push('<' + getUri(pageCount) + '>; rel="last"');
 
-    if (hasNext) {
-      links.push('<' + getUri(currentPage + 1) + '>; rel="next"');
+      if (hasNext) {
+        links.push('<' + getUri(currentPage + 1) + '>; rel="next"');
+      }
+
+      if (hasPrevious) {
+        links.push('<' + getUri(currentPage - 1) + '>; rel="prev"');
+      }
+
+      request.response.headers['Content-Range'] = startIndex + '-' + endIndex + '/' + totalCount;
+      request.response.headers['Link'] = links;
+
+      if (internals.config.meta.successStatusCode) {
+        request.response.code(internals.config.meta.successStatusCode);
+      }
     }
 
-    if (hasPrevious) {
-      links.push('<' + getUri(currentPage - 1) + '>; rel="prev"');
-    }
-
-    request.response.headers['Content-Range'] = startIndex + '-' + endIndex + '/' + totalCount;
-    request.response.headers['Link'] = links;
     request.response.source = results;
   }
   else {
-
     internals.assignIfActive(meta, 'page',        query[internals.name('page')]);
     internals.assignIfActive(meta, 'limit',       query[internals.name('limit')]);
 
@@ -242,10 +248,10 @@ internals.onPreResponse = function (request, reply) {
         }
       }
     }
-  }
 
-  if (internals.config.meta.successStatusCode) {
-    request.response.code(internals.config.meta.successStatusCode);
+    if (internals.config.meta.successStatusCode) {
+      request.response.code(internals.config.meta.successStatusCode);
+    }
   }
 
   return reply.continue();

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -188,7 +188,7 @@ internals.onPreResponse = function (request, reply) {
   if (internals.config.meta.location === 'header') {
     delete request.response.headers['total-count']
 
-    if (totalCount > currentLimit) {
+    if (totalCount > currentLimit && results.length > 0) {
       // put metadata in headers rather than in body
       const startIndex = currentLimit * (currentPage - 1);
       const endIndex = startIndex + results.length - 1;

--- a/test/test.js
+++ b/test/test.js
@@ -899,7 +899,8 @@ describe('Override default values', () => {
             }
           },
           meta: {
-            location: 'header'
+            location: 'header',
+            successStatusCode: 206
           }
         };
 
@@ -914,6 +915,8 @@ describe('Override default values', () => {
             method: 'GET',
             url: '/users'
           }, (res) => {
+            const statusCode = res.request.response.statusCode
+            expect(statusCode).to.equal(206)
             const headers = res.request.response.headers;
             const response = res.request.response.source;
             expect(headers['Content-Range']).to.equal('5-9/20');
@@ -935,6 +938,47 @@ describe('Override default values', () => {
       it('Override meta location - move metadata to http headers with unique page', (done) => {
         const options = {
           meta: {
+            location: 'header',
+            successStatusCode: 206
+          }
+        };
+
+        const server = register();
+        server.register({
+          register: require(pluginName),
+          options: options
+        }, (err) => {
+          expect(err).to.be.undefined();
+
+          server.inject({
+            method: 'GET',
+            url: '/users'
+          }, (res) => {
+            const statusCode = res.request.response.statusCode
+            expect(statusCode).to.equal(200)
+            const headers = res.request.response.headers;
+            const response = res.request.response.source;
+            expect(headers['Content-Range']).to.not.exist;
+            expect(headers['Link']).to.not.exist;
+            expect(response).to.be.an.array();
+            expect(response).to.have.length(20);
+
+            done();
+          })
+        })
+      })
+
+      it('Override meta location - move metadata to http headers with first page', (done) => {
+        const options = {
+          query: {
+            limit: {
+              default: 5
+            },
+            page: {
+              default: 1
+            }
+          },
+          meta: {
             location: 'header'
           }
         };
@@ -950,16 +994,66 @@ describe('Override default values', () => {
             method: 'GET',
             url: '/users'
           }, (res) => {
+            const statusCode = res.request.response.statusCode
+            expect(statusCode).to.equal(200)
             const headers = res.request.response.headers;
             const response = res.request.response.source;
-            expect(headers['Content-Range']).to.equal('0-19/20');
+            expect(headers['Content-Range']).to.equal('0-4/20');
             expect(headers['Link']).to.be.an.array();
-            expect(headers['Link']).to.have.length(3);
+            expect(headers['Link']).to.have.length(4);
             expect(headers['Link'][0]).match(/rel="self"$/);
             expect(headers['Link'][1]).match(/rel="first"$/);
             expect(headers['Link'][2]).match(/rel="last"$/);
+            expect(headers['Link'][3]).match(/rel="next"$/);
+
             expect(response).to.be.an.array();
-            expect(response).to.have.length(20);
+            expect(response).to.have.length(5);
+
+            done();
+          })
+        })
+      })
+
+      it('Override meta location - move metadata to http headers with last page', (done) => {
+        const options = {
+          query: {
+            limit: {
+              default: 5
+            },
+            page: {
+              default: 4
+            }
+          },
+          meta: {
+            location: 'header'
+          }
+        };
+
+        const server = register();
+        server.register({
+          register: require(pluginName),
+          options: options
+        }, (err) => {
+          expect(err).to.be.undefined();
+
+          server.inject({
+            method: 'GET',
+            url: '/users'
+          }, (res) => {
+            const statusCode = res.request.response.statusCode
+            expect(statusCode).to.equal(200)
+            const headers = res.request.response.headers;
+            const response = res.request.response.source;
+            expect(headers['Content-Range']).to.equal('15-19/20');
+            expect(headers['Link']).to.be.an.array();
+            expect(headers['Link']).to.have.length(4);
+            expect(headers['Link'][0]).match(/rel="self"$/);
+            expect(headers['Link'][1]).match(/rel="first"$/);
+            expect(headers['Link'][2]).match(/rel="last"$/);
+            expect(headers['Link'][3]).match(/rel="prev"$/);
+
+            expect(response).to.be.an.array();
+            expect(response).to.have.length(5);
 
             done();
           })

--- a/test/test.js
+++ b/test/test.js
@@ -806,6 +806,41 @@ describe('Override default values', () => {
         });
     });
 
+    it('Override query parameter pagination - set active to false', (done) => {
+      const options = {
+        query: {
+          limit: {
+            default: 10
+          },
+          pagination: {
+            default: true,
+            active: false
+          }
+        }
+      };
+
+      const server = register();
+      server.register({
+          register: require(pluginName),
+          options: options
+      }, (err) => {
+
+          expect(err).to.be.undefined();
+
+          server.inject({
+              method: 'GET',
+              url: '/users?pagination=false'
+          }, (res) => {
+
+              const response = res.request.response.source;
+              expect(response.results).to.be.an.array();
+              expect(response.results).to.have.length(10);
+
+              done();
+          });
+      });
+    })
+
     it('Override meta - set active to false', (done) => {
 
         const options = {

--- a/test/test.js
+++ b/test/test.js
@@ -1095,6 +1095,49 @@ describe('Override default values', () => {
         })
       })
 
+      it('Override meta location - do not set metadata if requested page is out of range', (done) => {
+        const options = {
+          query: {
+            limit: {
+              default: 5
+            },
+            page: {
+              default: 5
+            }
+          },
+          meta: {
+            location: 'header',
+            successStatusCode: 206
+          }
+        };
+
+        const server = register();
+        server.register({
+          register: require(pluginName),
+          options: options
+        }, (err) => {
+          expect(err).to.be.undefined();
+
+          server.inject({
+            method: 'GET',
+            url: '/users'
+          }, (res) => {
+            const statusCode = res.request.response.statusCode
+            expect(statusCode).to.equal(200)
+
+            const headers = res.request.response.headers;
+            expect(headers['Content-Range']).to.not.exist;
+            expect(headers['Link']).to.not.exist;
+
+            const response = res.request.response.source;
+            expect(response).to.be.an.array();
+            expect(response).to.have.length(0);
+
+            done();
+          })
+        })
+      })
+
     it('use custom baseUri instead of server provided uri', (done) => {
 
         const myCustomUri = 'https://127.0.0.1:81';


### PR DESCRIPTION
generate status code 206 and HTP headers if result actually paginated,
generate default status code and no headers if the whole result is returned in one page.