### PR TITLE
Multi-Connection Support

### DIFF
--- a/lib/ext.js
+++ b/lib/ext.js
@@ -5,269 +5,261 @@ const Boom = require('boom');
 const Hoek = require('hoek');
 const Qs = require('querystring');
 
-const internals = {};
+// module.exports = function (config) {
 
-internals.getRouteOptions = function (request) {
+//   internals.config = config;
 
-  return request.route.settings.plugins.pagination || {};
-};
+//   return {
+//       onPreHandler: internals.onPreHandler,
+//       onPostHandler: internals.onPostHandler
+//   };
+// };
 
-
-internals.containsPath = function (array, path) {
-
-  return Utils.some(array, (item) => {
-    return item instanceof RegExp ? item.test(path) : item === path;
-  });
-},
-
-
-internals.isValidRoute = function (request) {
-
-  const include = internals.config.routes.include;
-  const exclude = internals.config.routes.exclude;
-  const options = internals.getRouteOptions(request);
-  const path    = request.route.path;
-  const method  = request.route.method;
-
-  if (!Utils.isUndefined(options.enabled)) {
-      return options.enabled;
+module.exports = class Ext {
+  constructor(config) {
+    this.config = config;
+  }
+  
+  getRouteOptions(request) {
+    return request.route.settings.plugins.pagination || {};
+  }
+  
+  containsPath(array, path) {
+    return Utils.some(array, (item) => {
+      return item instanceof RegExp ? item.test(path) : item === path;
+    });
   }
 
-  return (
-    (method === 'get') &&
-    (include[0] === '*' || internals.containsPath(include, path)) &&
-    (!internals.containsPath(exclude, path))
-  );
-};
+  isValidRoute(request) {
+    const include = this.config.routes.include;
+    const exclude = this.config.routes.exclude;
+    const options = this.getRouteOptions(request);
+    const path    = request.route.path;
+    const method  = request.route.method;
 
-
-internals.getPagination = function (request, config) {
-  if (config.query.pagination.active) {
-    const pagination = request.query[config.query.pagination.name];
-
-    if (pagination === 'false' || pagination === false) {
-      return false;
+    if (!Utils.isUndefined(options.enabled)) {
+        return options.enabled;
     }
 
-    if (pagination === 'true' || pagination === true) {
-      return true;
+    return (
+      (method === 'get') &&
+      (include[0] === '*' || this.containsPath(include, path)) &&
+      (!this.containsPath(exclude, path))
+    );
+  }
+
+  getPagination(request) {
+    if (this.config.query.pagination.active) {
+      const pagination = request.query[this.config.query.pagination.name];
+
+      if (pagination === 'false' || pagination === false) {
+        return false;
+      }
+
+      if (pagination === 'true' || pagination === true) {
+        return true;
+      }
+    }
+
+    const routeDefaults = this.getRouteOptions(request).defaults || {};
+
+    if (!Utils.isUndefined(routeDefaults.pagination)) {
+      return routeDefaults.pagination;
+    }
+
+    return this.config.query.pagination.default;
+  }
+
+  name(arg) {
+    return this.config.meta[arg].name;
+  }
+
+  assignIfActive(meta, name, value) {
+    if (this.config.meta[name].active) {
+        meta[this.name(name)] = value;
     }
   }
 
-  const routeDefaults = internals.getRouteOptions(request).defaults || {};
+  onPreHandler(request, reply) {
+    // If the route does not match, just skip this part
+    if (this.isValidRoute(request)) {
 
-  if (!Utils.isUndefined(routeDefaults.pagination)) {
-    return routeDefaults.pagination;
-  }
+      const routeDefaults = this.getRouteOptions(request).defaults || {};
+      const pagination = this.getPagination(request);
+      request.query[this.config.query.pagination.name] = pagination;
 
-  return config.query.pagination.default;
-};
+      if (pagination === false) {
+        return reply.continue();
+      }
 
+      const page  = routeDefaults.page  || this.config.query.page.default;
+      const limit = routeDefaults.limit || this.config.query.limit.default;
 
-internals.name = function (arg) {
+      const setParam = (arg, defaultValue) => {
 
-  return internals.config.meta[arg].name;
-};
+        const name = this.name(arg);
+        let value = null;
 
+        if (request.query[name] || request.query[name] === 0) {
+          value = parseInt(request.query[name]);
 
-internals.assignIfActive = function (meta, name, value) {
+          if (Utils.isNaN(value)) {
+            if (this.config.query.invalid === 'defaults') {
+              value = this.config.query[arg].default;
+            }
+            else {
+              return { message: 'Invalid ' + name };
+            }
+          }
+        }
 
-  if (internals.config.meta[name].active) {
-      meta[internals.name(name)] = value;
-  }
-};
+        request.query[name] = value || defaultValue;
+        return null;
+      };
 
-internals.onPreHandler = function (request, reply) {
+      let err = setParam('page', page);
 
-  // If the route does not match, just skip this part
-  if (internals.isValidRoute(request)) {
+      if (!err) {
+        err = setParam('limit', limit);
+      }
 
-    const routeDefaults = internals.getRouteOptions(request).defaults || {};
-    const pagination = internals.getPagination(request, internals.config);
-    request.query[internals.config.query.pagination.name] = pagination;
+      if (err) {
+        return reply(Boom.badRequest(err.message));
+      }
+    }
 
-    if (pagination === false) {
+    return reply.continue();
+  };
+
+  onPostHandler(request, reply) {
+
+    const processResponse =
+        this.isValidRoute(request) &&
+        !request.response.isBoom &&
+        this.getPagination(request);
+
+    if (!processResponse) {
       return reply.continue();
     }
 
-    const page  = routeDefaults.page  || internals.config.query.page.default;
-    const limit = routeDefaults.limit || internals.config.query.limit.default;
+    // Removes pagination from query parameters if default is true
+    // If defaults is false, paginaton param is needed in the generated links
+    if (this.config.query.pagination.default) {
+      delete request.query[this.config.query.pagination.name];
+    }
 
-    const setParam = function (arg, defaultValue) {
+    const source = request.response.source;
+    const results = Array.isArray(source) ? source : source[this.config.reply.parameters.results.name];
+    Hoek.assert(Array.isArray(results), 'The results must be an array');
 
-      const name = internals.name(arg);
-      let value = null;
+    const baseUri = this.config.uri + request.url.pathname + '?';
+    const query = request.query; // Query parameters
+    const currentPage  = query[this.config.query.page.name];
+    const currentLimit = query[this.config.query.limit.name];
 
-      if (request.query[name] || request.query[name] === 0) {
-        value = parseInt(request.query[name]);
+    const totalCount = Utils.isUndefined(source[this.config.reply.parameters.totalCount.name])
+                        ? Utils.isUndefined(request.response.headers['total-count'])
+                          ? request[this.config.meta.totalCount.name]
+                          : request.response.headers['total-count']
+                        : source[this.config.reply.parameters.totalCount.name];
 
-        if (Utils.isNaN(value)) {
-          if (internals.config.query.invalid === 'defaults') {
-            value = internals.config.query[arg].default;
-          }
-          else {
-            return { message: 'Invalid ' + name };
+    let pageCount = null;
+    if (!Utils.isNil(totalCount)) {
+      pageCount =
+        Math.trunc(totalCount / currentLimit) + (totalCount % currentLimit === 0 ? 0 : 1);
+    }
+
+    const getUri = (page) => {
+
+      if (!page) {
+        return null;
+      }
+
+      // Override page
+      const qs = Hoek.applyToDefaults(query, {
+        [this.config.query.page.name]: page
+      });
+
+      return baseUri + Qs.stringify(qs);
+    };
+
+    const meta = {};
+    const hasNext = !Utils.isNil(totalCount) && totalCount !== 0 && currentPage < pageCount;
+    const hasPrevious = !Utils.isNil(totalCount) && totalCount !== 0 && currentPage > 1;
+
+    if (this.config.meta.location === 'header') {
+      delete request.response.headers['total-count']
+
+      if (totalCount > currentLimit && results.length > 0) {
+        // put metadata in headers rather than in body
+        const startIndex = currentLimit * (currentPage - 1);
+        const endIndex = startIndex + results.length - 1;
+
+        const links = [];
+        links.push('<' + getUri(currentPage) + '>; rel="self"');
+        links.push('<' + getUri(1) + '>; rel="first"');
+        links.push('<' + getUri(pageCount) + '>; rel="last"');
+
+        if (hasNext) {
+          links.push('<' + getUri(currentPage + 1) + '>; rel="next"');
+        }
+
+        if (hasPrevious) {
+          links.push('<' + getUri(currentPage - 1) + '>; rel="prev"');
+        }
+
+        request.response.headers['Content-Range'] = startIndex + '-' + endIndex + '/' + totalCount;
+        request.response.headers['Link'] = links;
+
+        if (this.config.meta.successStatusCode) {
+          request.response.code(this.config.meta.successStatusCode);
+        }
+      }
+
+      request.response.source = results;
+    }
+    else {
+      this.assignIfActive(meta, 'page',        query[this.name('page')]);
+      this.assignIfActive(meta, 'limit',       query[this.name('limit')]);
+
+      this.assignIfActive(meta, 'count',       results.length);
+      this.assignIfActive(meta, 'pageCount',   pageCount);
+      this.assignIfActive(meta, 'totalCount',  Utils.isNil(totalCount) ? null : totalCount);
+
+      this.assignIfActive(meta, 'next',        hasNext ? getUri(currentPage + 1) : null);
+      this.assignIfActive(meta, 'previous',    getUri(currentPage - 1));
+      this.assignIfActive(meta, 'hasNext',     hasNext);
+      this.assignIfActive(meta, 'hasPrevious', hasPrevious);
+
+      this.assignIfActive(meta, 'self',        getUri(currentPage));
+      this.assignIfActive(meta, 'first',       getUri(1));
+      this.assignIfActive(meta, 'last',        getUri(pageCount));
+
+
+      const response = {
+        [this.config.meta.name]: meta,
+        [this.config.results.name]: results
+      };
+
+      if (source.response) {
+        const keys = Object.keys(source.response);
+
+        for (let i = 0; i < keys.length; ++i) {
+          const key = keys[i];
+          if (key !== this.config.meta.name &&
+              key !== this.config.results.name) {
+            response[key] = source.response[key];
           }
         }
       }
 
-      request.query[name] = value || defaultValue;
-      return null;
-    };
+      if (this.config.meta.successStatusCode) {
+        return reply.continue(response).code(this.config.meta.successStatusCode);
+      }
 
-    let err = setParam('page', page);
-
-    if (!err) {
-      err = setParam('limit', limit);
+      return reply.continue(response);
     }
 
-    if (err) {
-      return reply(Boom.badRequest(err.message));
-    }
-  }
-
-  return reply.continue();
-};
-
-internals.onPostHandler = function (request, reply) {
-
-  const processResponse =
-      internals.isValidRoute(request) &&
-      !request.response.isBoom &&
-      internals.getPagination(request, internals.config);
-
-  if (!processResponse) {
     return reply.continue();
   }
-
-  // Removes pagination from query parameters if default is true
-  // If defaults is false, paginaton param is needed in the generated links
-  if (internals.config.query.pagination.default) {
-    delete request.query[internals.config.query.pagination.name];
-  }
-
-  const source = request.response.source;
-  const results = Array.isArray(source) ? source : source[internals.config.reply.parameters.results.name];
-  Hoek.assert(Array.isArray(results), 'The results must be an array');
-
-  const baseUri = internals.config.uri + request.url.pathname + '?';
-  const query = request.query; // Query parameters
-  const currentPage  = query[internals.config.query.page.name];
-  const currentLimit = query[internals.config.query.limit.name];
-
-  const totalCount = Utils.isUndefined(source[internals.config.reply.parameters.totalCount.name])
-                      ? Utils.isUndefined(request.response.headers['total-count'])
-                        ? request[internals.config.meta.totalCount.name]
-                        : request.response.headers['total-count']
-                      : source[internals.config.reply.parameters.totalCount.name];
-
-  let pageCount = null;
-  if (!Utils.isNil(totalCount)) {
-    pageCount =
-      Math.trunc(totalCount / currentLimit) + (totalCount % currentLimit === 0 ? 0 : 1);
-  }
-
-  const getUri = function (page) {
-
-    if (!page) {
-      return null;
-    }
-
-    // Override page
-    const qs = Hoek.applyToDefaults(query, {
-      [internals.config.query.page.name]: page
-    });
-
-    return baseUri + Qs.stringify(qs);
-  };
-
-  const meta = {};
-  const hasNext = !Utils.isNil(totalCount) && totalCount !== 0 && currentPage < pageCount;
-  const hasPrevious = !Utils.isNil(totalCount) && totalCount !== 0 && currentPage > 1;
-
-  if (internals.config.meta.location === 'header') {
-    delete request.response.headers['total-count']
-
-    if (totalCount > currentLimit && results.length > 0) {
-      // put metadata in headers rather than in body
-      const startIndex = currentLimit * (currentPage - 1);
-      const endIndex = startIndex + results.length - 1;
-
-      const links = [];
-      links.push('<' + getUri(currentPage) + '>; rel="self"');
-      links.push('<' + getUri(1) + '>; rel="first"');
-      links.push('<' + getUri(pageCount) + '>; rel="last"');
-
-      if (hasNext) {
-        links.push('<' + getUri(currentPage + 1) + '>; rel="next"');
-      }
-
-      if (hasPrevious) {
-        links.push('<' + getUri(currentPage - 1) + '>; rel="prev"');
-      }
-
-      request.response.headers['Content-Range'] = startIndex + '-' + endIndex + '/' + totalCount;
-      request.response.headers['Link'] = links;
-
-      if (internals.config.meta.successStatusCode) {
-        request.response.code(internals.config.meta.successStatusCode);
-      }
-    }
-
-    request.response.source = results;
-  }
-  else {
-    internals.assignIfActive(meta, 'page',        query[internals.name('page')]);
-    internals.assignIfActive(meta, 'limit',       query[internals.name('limit')]);
-
-    internals.assignIfActive(meta, 'count',       results.length);
-    internals.assignIfActive(meta, 'pageCount',   pageCount);
-    internals.assignIfActive(meta, 'totalCount',  Utils.isNil(totalCount) ? null : totalCount);
-
-    internals.assignIfActive(meta, 'next',        hasNext ? getUri(currentPage + 1) : null);
-    internals.assignIfActive(meta, 'previous',    getUri(currentPage - 1));
-    internals.assignIfActive(meta, 'hasNext',     hasNext);
-    internals.assignIfActive(meta, 'hasPrevious', hasPrevious);
-
-    internals.assignIfActive(meta, 'self',        getUri(currentPage));
-    internals.assignIfActive(meta, 'first',       getUri(1));
-    internals.assignIfActive(meta, 'last',        getUri(pageCount));
-
-
-    const response = {
-      [internals.config.meta.name]: meta,
-      [internals.config.results.name]: results
-    };
-
-    if (source.response) {
-      const keys = Object.keys(source.response);
-
-      for (let i = 0; i < keys.length; ++i) {
-        const key = keys[i];
-        if (key !== internals.config.meta.name &&
-            key !== internals.config.results.name) {
-          response[key] = source.response[key];
-        }
-      }
-    }
-
-    if (internals.config.meta.successStatusCode) {
-      return reply.continue(response).code(internals.config.meta.successStatusCode);
-    }
-
-    return reply.continue(response);
-  }
-
-  return reply.continue();
-};
-
-
-module.exports = function (config) {
-
-  internals.config = config;
-
-  return {
-      onPreHandler: internals.onPreHandler,
-      onPostHandler: internals.onPostHandler
-  };
-};
+}

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -5,16 +5,6 @@ const Boom = require('boom');
 const Hoek = require('hoek');
 const Qs = require('querystring');
 
-// module.exports = function (config) {
-
-//   internals.config = config;
-
-//   return {
-//       onPreHandler: internals.onPreHandler,
-//       onPostHandler: internals.onPostHandler
-//   };
-// };
-
 module.exports = class Ext {
   constructor(config) {
     this.config = config;

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,17 +5,6 @@ const Ext = require('./ext');
 
 exports.register = function (server, options, next) {
 
-  if (server.connections.length !== 1) {
-    return next({
-      name: 'ValidationError',
-      details: {
-        message: 'You cannot register this plugin for two connections at once. \n' +
-                  'Register it for each connection on your server.',
-        context: server.connections
-      }
-    });
-  }
-
   const result = Config.getConfig(server, options);
 
   if (result.error) {
@@ -23,6 +12,16 @@ exports.register = function (server, options, next) {
   }
 
   const config = result.config;
+
+  if (typeof config.meta.baseUri === 'undefined' && server.info === null) {
+    return next({
+      name: 'ValidationError',
+      details: {
+        message: 'You cannot register this plugin for multiple connections at once without providing the baseUri configuration option.',
+        context: server.connections
+      }
+    });
+  }
 
   // For simplicity
   config.meta.page.name = config.query.page.name;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Config = require('./config');
+const Ext = require('./ext');
 
 exports.register = function (server, options, next) {
 
@@ -31,12 +32,17 @@ exports.register = function (server, options, next) {
   config.uri = typeof config.meta.baseUri !== 'undefined' ? config.meta.baseUri : server.info.uri;
 
   const decorate = require('./decorate')(config);
-  const ext      = require('./ext')(config);
+  const ext = new Ext(config);
 
-  server.decorate('reply', config.reply.paginate, decorate.paginate);
-  Object.keys(ext).forEach((key) => {
-    server.ext(key, ext[key]);
-  });
+  try {
+      server.decorate('reply', config.reply.paginate, decorate.paginate);
+  } catch (err) {
+      // Decoration can be defined once for the entire server.
+      // Error: Reply interface decoration already defined.
+  }
+
+  server.ext('onPreHandler', (request, reply) => ext.onPreHandler(request, reply));
+  server.ext('onPostHandler', (request, reply) => ext.onPostHandler(request, reply));
 
   return next();
 };

--- a/test/multiConnectionTest.js
+++ b/test/multiConnectionTest.js
@@ -1,0 +1,119 @@
+'use strict';
+
+const Code = require('code');
+const Lab = require('lab');
+const lab = exports.lab = Lab.script();
+const Hapi = require('hapi');
+
+const describe = lab.describe;
+const it = lab.it;
+const expect = Code.expect;
+
+const pluginName = '../lib';
+
+const users = [];
+for (let i = 0; i < 20; ++i) {
+	users.push({
+		name: `name${i}`,
+		username: `username${i}`
+	});
+}
+
+const register = () => {
+	return new Promise((resolve) => {
+		const server = new Hapi.Server();
+
+		const connectionOne = server.connection({
+			host: 'localhost',
+			port: 0,
+			labels: ['connection1']
+		});
+
+		const connectionTwo = server.connection({
+			host: 'localhost',
+			port: 0,
+			labels: ['connection2']
+		});
+
+		connectionOne.route({
+			method: 'GET',
+			path: '/users',
+			handler: (request, reply) => {
+				request.totalCount = 20;
+				return reply(users);
+			}
+		});
+
+		connectionTwo.route({
+			method: 'GET',
+			path: '/users2',
+			handler: (request, reply) => {
+				request.totalCount = 20;
+				return reply(users);
+			}
+		});
+
+		Promise.all([
+				connectionOne.register({
+					register: require(pluginName),
+					options: {
+						meta: {
+							name: 'metaConnection1'
+						},
+						results: {
+							name: 'connection1'
+						}
+					}
+				}),
+				connectionTwo.register({
+					register: require(pluginName),
+					options: {
+						meta: {
+							name: 'metaConnection2'
+						},
+						results: {
+							name: 'connection2'
+						}
+					}
+				})
+			])
+			.then(() => {
+				resolve(server);
+			})
+			.catch(() => resolve(server));
+	});
+};
+
+describe('Multi Connections Tetsts', () => {
+
+	it('Connection One', (done) => {
+		register().then((server) => {
+			server.select('connection1').inject({
+				method: 'GET',
+				url: '/users'
+			}, (res) => {
+				expect(res.request.response.source.connection1).to.be.an.array();
+				expect(res.request.response.source.connection1).to.have.length(20);
+				expect(res.request.response.source.metaConnection1.totalCount).to.equal(20);
+
+				done();
+			});
+		});
+	});
+
+	it('Connection Two', (done) => {
+		register().then((server) => {
+			server.select('connection2').inject({
+				method: 'GET',
+				url: '/users2'
+			}, (res) => {
+				expect(res.request.response.source.connection2).to.be.an.array();
+				expect(res.request.response.source.connection2).to.have.length(20);
+				expect(res.request.response.source.metaConnection2.totalCount).to.equal(20);
+
+				done();
+			});
+		});
+	});
+
+});

--- a/test/test.js
+++ b/test/test.js
@@ -19,8 +19,8 @@ for (let i = 0; i < 20; ++i) {
     });
 }
 
-const register = function (connections = [{ host: 'localhost' }]) {
-
+const register = function (connections) {
+    connections = connections || [{ host: 'localhost' }];
     const server = new Hapi.Server();
     connections.forEach((connection) => server.connection(connection));
 


### PR DESCRIPTION
Addresses Issue #44 with parts of PR #17.

* Changes Ext to a class to scope the config per call to `register`
* Adds guard when registering on multiple connections at once to ensure a `baseUri` configuration option is passed
* Adds tests for registering to individual connections as well as multiple connections at once