### PR TITLE
update readme Joi validate syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,8 +409,8 @@ You don't need this if you don't need to validate anything !
 validate: {
   query: {
     // Your other parameters ...
-    limit: Joi.number.integer(),
-    page: Joi.number.integer(),
+    limit: Joi.number().integer(),
+    page: Joi.number().integer(),
     pagination: Joi.boolean()
   }
 }


### PR DESCRIPTION
The documentation example uses `Joi.number.integer()` per documentation and testing it requires `Joi.number().integer()`

https://github.com/hapijs/joi/blob/v10.5.2/API.md#numberinteger