### PR TITLE
Fix: Reply without modifying response when an error/exception is thrown from handler #9

### DIFF
--- a/lib/ext.js
+++ b/lib/ext.js
@@ -126,6 +126,7 @@ module.exports = class Ext {
     const processResponse =
         this.isValidRoute(request) &&
         !request.response.isBoom &&
+        request.response.statusCode === 200 &&
         this.getPagination(request);
 
     if (!processResponse) {
@@ -137,12 +138,9 @@ module.exports = class Ext {
     if (this.config.query.pagination.default) {
       delete request.query[this.config.query.pagination.name];
     }
-    
     const response = request.response;
     const source = response.source;
-    if (response.statusCode !== 200) {
-      return reply.continue(response);
-    }
+
     const results = Array.isArray(source) ? source : source[this.config.reply.parameters.results.name];
     Hoek.assert(Array.isArray(results), 'The results must be an array');
 

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -123,10 +123,12 @@ module.exports = class Ext {
 
   onPostHandler(request, reply) {
 
+    const statusCode = request.response.statusCode;
     const processResponse =
         this.isValidRoute(request) &&
         !request.response.isBoom &&
-        request.response.statusCode === 200 &&
+        statusCode >= 200 &&
+        statusCode <= 299 &&
         this.getPagination(request);
 
     if (!processResponse) {

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -138,9 +138,8 @@ module.exports = class Ext {
     if (this.config.query.pagination.default) {
       delete request.query[this.config.query.pagination.name];
     }
-    const response = request.response;
-    const source = response.source;
 
+    const source = request.response.source;
     const results = Array.isArray(source) ? source : source[this.config.reply.parameters.results.name];
     Hoek.assert(Array.isArray(results), 'The results must be an array');
 

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -137,8 +137,12 @@ module.exports = class Ext {
     if (this.config.query.pagination.default) {
       delete request.query[this.config.query.pagination.name];
     }
-
-    const source = request.response.source;
+    
+    const response = request.response;
+    const source = response.source;
+    if (response.statusCode !== 200) {
+      return reply.continue(response);
+    }
     const results = Array.isArray(source) ? source : source[this.config.reply.parameters.results.name];
     Hoek.assert(Array.isArray(results), 'The results must be an array');
 

--- a/test/test.js
+++ b/test/test.js
@@ -189,6 +189,18 @@ const register = function (connections) {
         handler: (request, reply) => reply('Works')
     });
 
+    server.route({
+      method: 'GET',
+      path: '/array-exception',
+      handler: (request, reply) => { 
+        const response = reply({
+          message: "Custom Error Message"
+        });
+        response.code(500);
+        return;
+      }
+    });
+
     return server;
 };
 
@@ -2227,6 +2239,23 @@ describe('Exception', () => {
         done();
       });
     
+    });
+  });
+  
+  it('Should not process further if response code is other than 200', (done) => {
+    const server = register();
+    server.register(require(pluginName), (err) => {
+        const request = {
+          method: 'GET',
+          url: '/array-exception'
+        };
+        server.inject(request, (res, err) => {
+          const response = res.request.response.source;
+          const message = response.message;
+          expect(message).to.equal("Custom Error Message");
+          expect(res.request.response.statusCode).to.equal(500);
+          done();
+        });
     });
   });
 });


### PR DESCRIPTION
If statusCode is other than 200 it won't show the message "The results must be an array" & continue with the given response