### PR TITLE
Use original query string-values to construct URLs

### DIFF
--- a/lib/ext.js
+++ b/lib/ext.js
@@ -168,8 +168,10 @@ module.exports = class Ext {
         return null;
       }
 
+      const origQuery = Hoek.applyToDefaults(query, request.orig.query);
+
       // Override page
-      const qs = Hoek.applyToDefaults(query, {
+      const qs = Hoek.applyToDefaults(origQuery, {
         [this.config.query.page.name]: page
       });
 

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -168,7 +168,7 @@ module.exports = class Ext {
         return null;
       }
 
-      const origQuery = Hoek.applyToDefaults(query, request.orig.query);
+      const origQuery = Object.assign({}, query, request.orig.query);
 
       // Override page
       const qs = Hoek.applyToDefaults(origQuery, {


### PR DESCRIPTION
When the query parameter is parsed by Joi as a date(), the value of the parameter is converted to an object. querystring.stringify() cannot un-parse the object into its original string form and as a result the _value_ of the parameter is stripped from the URL. The parameter _name_ is included in the URL.