### PR TITLE
Allow POST pagination

### DIFF
--- a/lib/ext.js
+++ b/lib/ext.js
@@ -38,7 +38,7 @@ module.exports = class Ext {
         }
 
         return (
-            (method === 'get') &&
+            (method === 'get' || method === 'post') &&
             (include[0] === '*' || this.containsPath(include, path)) &&
             (!this.containsPath(exclude, path))
         );


### PR DESCRIPTION
A common use-case for pagination is on search endpoints which in most cases will be POST instead of GET but the package currently only allows GET endpoints to be paginated.

I don't know the reason why only GET endpoints can be paginated so please let me know if this works.