### PR TITLE
Include custom headers from pre-processed response

### DIFF
--- a/lib/ext.js
+++ b/lib/ext.js
@@ -240,7 +240,7 @@ module.exports = class Ext {
             this.assignIfActive(meta, 'last', getUri(pageCount));
 
 
-            const response = {
+            const newSource = {
                 [this.config.meta.name]: meta,
                 [this.config.results.name]: results
             };
@@ -252,16 +252,16 @@ module.exports = class Ext {
                     const key = keys[i];
                     if (key !== this.config.meta.name &&
                         key !== this.config.results.name) {
-                        response[key] = source.response[key];
+                        newSource[key] = source.response[key];
                     }
                 }
             }
 
             if (this.config.meta.successStatusCode) {
-                return h.response(response).code(this.config.meta.successStatusCode);
+                request.response.code(this.config.meta.successStatusCode);
             }
 
-            return h.response(response);
+            request.response.source = newSource;
         }
 
         return h.continue;

--- a/test/test.js
+++ b/test/test.js
@@ -237,6 +237,14 @@ const register = function () {
         }
     });
 
+    server.route({
+        method: 'GET',
+        path: '/custom-header',
+        handler: (request, h) => {
+            return h.paginate([{}, {}, {}], 3).header('custom-header', 'pizza');
+        }
+    });
+
     return server;
 };
 
@@ -2333,4 +2341,29 @@ describe('Should include original values of query parameters in pagination urls 
         expect(splitParams(response.meta.last)).to.include(objectQuery);
 
     });
+});
+
+describe('Include custom headers', () => {
+    it('Should include any custom-header set in the pre-processed response', async () => {
+        const server = register();
+        await server.register(require(pluginName));
+
+        const request = {
+            method: 'GET',
+            url: `/custom-header`
+        };
+
+        const customHeaderName = 'custom-header';
+        const customHeaderValue = 'pizza';
+        const expectedCount = 3;
+        const expectedPageCount = 1;
+
+        const res = await server.inject(request);
+        expect(res.request.response.headers[customHeaderName]).to.equal(customHeaderValue);
+
+        const response = res.request.response.source;
+        expect(response.meta.count).to.equal(expectedCount);
+        expect(response.meta.pageCount).to.equal(expectedPageCount);
+        expect(response.meta.totalCount).to.equal(expectedCount);
+    });  
 });


### PR DESCRIPTION
This pull request allows headers (and other response properties) set in a handler to be present after `onPostHandler` -- when pagination info is returned as part of the body.

Example:
`
return h.paginate(...).headers('My-Header', 'value');
`

In the current version, the header is not present in the final response because the original response is replaced by a new one:
- https://github.com/fknop/hapi-pagination/blob/master/lib/ext.js#L264
- https://github.com/fknop/hapi-pagination/blob/master/lib/ext.js#L261

It seems that just changing the source of the original response is appropriate - all tests still pass.  Is there a reason to replace the original response entirely?