### PR TITLE
Optionally allow for a starting page index of 0 instead of 1

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "none",
+  "tabWidth": 4,
+  "singleQuote": true,
+  "semi": true
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,6 @@
 {
   "trailingComma": "none",
-  "tabWidth": 4,
+  "tabWidth": 2,
   "singleQuote": true,
-  "semi": true
+  "semi": false
 }

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ your calls to your API to suit your needs.
 
 See the default options object below.
 
+#### Root-level parameters
+
+* `zeroIndex`: Defaults to `false`; change this to `true` if you want to start paginating at page 0 instead of page 1
+
 #### The query parameters
 
 The plugin accepts query parameters to handle the pagination, you can customize
@@ -293,7 +297,8 @@ const options = {
     routes: {
         include: ['*'],
         exclude: []
-    }
+    },
+    zeroIndex: false
 };
 ```
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,116 +1,116 @@
-'use strict';
+'use strict'
 
-const Hoek = require('@hapi/hoek');
-const Joi = require('@hapi/joi');
-const Utils = require('./utils');
+const Hoek = require('@hapi/hoek')
+const Joi = require('@hapi/joi')
+const Utils = require('./utils')
 
 const internals = {
-    defaults: require('./defaults'),
-    schemas: {}
-};
+  defaults: require('./defaults'),
+  schemas: {}
+}
 
 internals.schemas.metaParameter = Joi.object({
-    active: Joi.boolean().required(),
-    name: Joi.string().required()
-});
+  active: Joi.boolean().required(),
+  name: Joi.string().required()
+})
 
 internals.schemas.replyParameter = Joi.object({
-    name: Joi.string().required()
-});
+  name: Joi.string().required()
+})
 
 internals.schemas.options = Joi.object({
-    query: Joi.object({
-        page: Joi.object({
-            name: Joi.string().required(),
-            default: Joi.number().integer().required()
-        }),
-        limit: Joi.object({
-            name: Joi.string().required(),
-            default: Joi.number().integer().positive().required()
-        }),
-        pagination: Joi.object({
-            name: Joi.string().required(),
-            default: Joi.boolean().required(),
-            active: Joi.boolean().required()
-        }),
-        invalid: Joi.string().required()
+  query: Joi.object({
+    page: Joi.object({
+      name: Joi.string().required(),
+      default: Joi.number().integer().required()
     }),
-    meta: Joi.object({
-        location: Joi.string().valid('body', 'header'),
-        successStatusCode: Joi.number().integer().min(200).less(300),
-        baseUri: Joi.string().allow(''),
-        name: Joi.string().required(),
-        count: internals.schemas.metaParameter,
-        totalCount: internals.schemas.metaParameter,
-        pageCount: internals.schemas.metaParameter,
-        self: internals.schemas.metaParameter,
-        previous: internals.schemas.metaParameter,
-        next: internals.schemas.metaParameter,
-        hasNext: internals.schemas.metaParameter,
-        hasPrevious: internals.schemas.metaParameter,
-        first: internals.schemas.metaParameter,
-        last: internals.schemas.metaParameter,
-        page: Joi.object({
-            active: Joi.boolean().required()
-        }),
-        limit: Joi.object({
-            active: Joi.boolean().required()
-        })
+    limit: Joi.object({
+      name: Joi.string().required(),
+      default: Joi.number().integer().positive().required()
     }),
-    results: Joi.object({
-        name: Joi.string().required()
+    pagination: Joi.object({
+      name: Joi.string().required(),
+      default: Joi.boolean().required(),
+      active: Joi.boolean().required()
     }),
-    reply: Joi.object({
-        paginate: Joi.string().required(),
-        parameters: {
-            results: internals.schemas.replyParameter,
-            totalCount: internals.schemas.replyParameter
-        }
+    invalid: Joi.string().required()
+  }),
+  meta: Joi.object({
+    location: Joi.string().valid('body', 'header'),
+    successStatusCode: Joi.number().integer().min(200).less(300),
+    baseUri: Joi.string().allow(''),
+    name: Joi.string().required(),
+    count: internals.schemas.metaParameter,
+    totalCount: internals.schemas.metaParameter,
+    pageCount: internals.schemas.metaParameter,
+    self: internals.schemas.metaParameter,
+    previous: internals.schemas.metaParameter,
+    next: internals.schemas.metaParameter,
+    hasNext: internals.schemas.metaParameter,
+    hasPrevious: internals.schemas.metaParameter,
+    first: internals.schemas.metaParameter,
+    last: internals.schemas.metaParameter,
+    page: Joi.object({
+      active: Joi.boolean().required()
     }),
-    routes: Joi.object({
-        include: Joi.array().items(
-            Joi.alternatives().try(Joi.object().type(RegExp), Joi.string())
-        ), // May register no routes...
-        exclude: Joi.array().items(
-            Joi.alternatives().try(Joi.object().type(RegExp), Joi.string())
-        )
-    }),
-    zeroIndex: Joi.boolean().required()
-});
+    limit: Joi.object({
+      active: Joi.boolean().required()
+    })
+  }),
+  results: Joi.object({
+    name: Joi.string().required()
+  }),
+  reply: Joi.object({
+    paginate: Joi.string().required(),
+    parameters: {
+      results: internals.schemas.replyParameter,
+      totalCount: internals.schemas.replyParameter
+    }
+  }),
+  routes: Joi.object({
+    include: Joi.array().items(
+      Joi.alternatives().try(Joi.object().type(RegExp), Joi.string())
+    ), // May register no routes...
+    exclude: Joi.array().items(
+      Joi.alternatives().try(Joi.object().type(RegExp), Joi.string())
+    )
+  }),
+  zeroIndex: Joi.boolean().required()
+})
 
 internals.schemas.routeOptions = Joi.object({
-    enabled: Joi.boolean(),
-    defaults: Joi.object({
-        page: Joi.number().integer().positive(),
-        limit: Joi.number().integer().positive(),
-        pagination: Joi.boolean()
-    })
-});
+  enabled: Joi.boolean(),
+  defaults: Joi.object({
+    page: Joi.number().integer().positive(),
+    limit: Joi.number().integer().positive(),
+    pagination: Joi.boolean()
+  })
+})
 
 const getConfig = (server, options) => {
-    const config = Hoek.applyToDefaults(internals.defaults, options);
-    const routeSettings = Utils.map(server.table(), (item) => item.settings);
+  const config = Hoek.applyToDefaults(internals.defaults, options)
+  const routeSettings = Utils.map(server.table(), (item) => item.settings)
 
-    // Check main config
-    const result = Joi.validate(config, internals.schemas.options);
-    if (result.error) {
-        return { error: result.error, config: null };
+  // Check main config
+  const result = Joi.validate(config, internals.schemas.options)
+  if (result.error) {
+    return { error: result.error, config: null }
+  }
+
+  // Check each route settings if config is valid
+  for (let i = 0; i < routeSettings.length; ++i) {
+    const res = Joi.validate(
+      routeSettings[i].plugins.pagination,
+      internals.schemas.routeOptions
+    )
+    if (res.error) {
+      return { error: res.error, config: null }
     }
+  }
 
-    // Check each route settings if config is valid
-    for (let i = 0; i < routeSettings.length; ++i) {
-        const res = Joi.validate(
-            routeSettings[i].plugins.pagination,
-            internals.schemas.routeOptions
-        );
-        if (res.error) {
-            return { error: res.error, config: null };
-        }
-    }
-
-    return { error: null, config: result.value };
-};
+  return { error: null, config: result.value }
+}
 
 module.exports = {
-    getConfig
-};
+  getConfig
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -9,7 +9,6 @@ const internals = {
     schemas: {}
 };
 
-
 internals.schemas.metaParameter = Joi.object({
     active: Joi.boolean().required(),
     name: Joi.string().required()
@@ -18,7 +17,6 @@ internals.schemas.metaParameter = Joi.object({
 internals.schemas.replyParameter = Joi.object({
     name: Joi.string().required()
 });
-
 
 internals.schemas.options = Joi.object({
     query: Joi.object({
@@ -70,11 +68,14 @@ internals.schemas.options = Joi.object({
         }
     }),
     routes: Joi.object({
-        include: Joi.array().items(Joi.alternatives().try(Joi.object().type(RegExp), Joi.string())), // May register no routes...
-        exclude: Joi.array().items(Joi.alternatives().try(Joi.object().type(RegExp), Joi.string()))
+        include: Joi.array().items(
+            Joi.alternatives().try(Joi.object().type(RegExp), Joi.string())
+        ), // May register no routes...
+        exclude: Joi.array().items(
+            Joi.alternatives().try(Joi.object().type(RegExp), Joi.string())
+        )
     })
 });
-
 
 internals.schemas.routeOptions = Joi.object({
     enabled: Joi.boolean(),
@@ -85,8 +86,7 @@ internals.schemas.routeOptions = Joi.object({
     })
 });
 
-const getConfig = function (server, options) {
-
+const getConfig = (server, options) => {
     const config = Hoek.applyToDefaults(internals.defaults, options);
     const routeSettings = Utils.map(server.table(), (item) => item.settings);
 
@@ -96,10 +96,12 @@ const getConfig = function (server, options) {
         return { error: result.error, config: null };
     }
 
-
     // Check each route settings if config is valid
     for (let i = 0; i < routeSettings.length; ++i) {
-        const res = Joi.validate(routeSettings[i].plugins.pagination, internals.schemas.routeOptions);
+        const res = Joi.validate(
+            routeSettings[i].plugins.pagination,
+            internals.schemas.routeOptions
+        );
         if (res.error) {
             return { error: res.error, config: null };
         }

--- a/lib/config.js
+++ b/lib/config.js
@@ -74,7 +74,8 @@ internals.schemas.options = Joi.object({
         exclude: Joi.array().items(
             Joi.alternatives().try(Joi.object().type(RegExp), Joi.string())
         )
-    })
+    }),
+    zeroIndex: Joi.boolean().required()
 });
 
 internals.schemas.routeOptions = Joi.object({

--- a/lib/config.js
+++ b/lib/config.js
@@ -75,7 +75,7 @@ internals.schemas.options = Joi.object({
       Joi.alternatives().try(Joi.object().type(RegExp), Joi.string())
     )
   }),
-  zeroIndex: Joi.boolean().required()
+  zeroIndex: Joi.boolean()
 })
 
 internals.schemas.routeOptions = Joi.object({
@@ -89,7 +89,7 @@ internals.schemas.routeOptions = Joi.object({
 
 const getConfig = (server, options) => {
   const config = Hoek.applyToDefaults(internals.defaults, options)
-  const routeSettings = Utils.map(server.table(), (item) => item.settings)
+  const routeSettings = server.table().map(item => item.settings);
 
   // Check main config
   const result = Joi.validate(config, internals.schemas.options)

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -1,41 +1,39 @@
-'use strict';
+'use strict'
 
-const Boom = require('@hapi/boom');
+const Boom = require('@hapi/boom')
 
 module.exports = function (config) {
-    return {
-        paginate: function (response, totalCount, options) {
-            options = options || {};
-            const key = options.key;
+  return {
+    paginate: function (response, totalCount, options) {
+      options = options || {}
+      const key = options.key
 
-            if (Array.isArray(response) && key) {
-                throw Boom.internal('Object required with results key');
-            }
+      if (Array.isArray(response) && key) {
+        throw Boom.internal('Object required with results key')
+      }
 
-            if (!Array.isArray(response) && !key) {
-                throw Boom.internal('Missing results key');
-            }
+      if (!Array.isArray(response) && !key) {
+        throw Boom.internal('Missing results key')
+      }
 
-            if (key && !response[key]) {
-                throw Boom.internal(
-                    'key: ' + key + 'does not exists on response'
-                );
-            }
+      if (key && !response[key]) {
+        throw Boom.internal('key: ' + key + 'does not exists on response')
+      }
 
-            const results = key ? response[key] : response;
-            if (key) {
-                delete response[key];
-            }
+      const results = key ? response[key] : response
+      if (key) {
+        delete response[key]
+      }
 
-            if (config.meta.location === 'header') {
-                return this.response(results).header('total-count', totalCount);
-            }
+      if (config.meta.location === 'header') {
+        return this.response(results).header('total-count', totalCount)
+      }
 
-            return this.response({
-                results,
-                totalCount,
-                response: Array.isArray(response) ? null : response
-            });
-        }
-    };
-};
+      return this.response({
+        results,
+        totalCount,
+        response: Array.isArray(response) ? null : response
+      })
+    }
+  }
+}

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -3,15 +3,13 @@
 const Boom = require('@hapi/boom');
 
 module.exports = function (config) {
-
     return {
         paginate: function (response, totalCount, options) {
-
             options = options || {};
             const key = options.key;
 
             if (Array.isArray(response) && key) {
-                throw Boom.internal('Object required with results key')
+                throw Boom.internal('Object required with results key');
             }
 
             if (!Array.isArray(response) && !key) {
@@ -19,7 +17,9 @@ module.exports = function (config) {
             }
 
             if (key && !response[key]) {
-                throw Boom.internal('key: ' + key + 'does not exists on response');
+                throw Boom.internal(
+                    'key: ' + key + 'does not exists on response'
+                );
             }
 
             const results = key ? response[key] : response;

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -90,5 +90,6 @@ module.exports = {
     routes: {
         include: ['*'],
         exclude: []
-    }
+    },
+    zeroIndex: false
 };

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,95 +1,95 @@
-'use strict';
+'use strict'
 
 module.exports = {
-    query: {
-        page: {
-            name: 'page',
-            default: 1
-        },
-        limit: {
-            name: 'limit',
-            default: 25
-        },
-        pagination: {
-            name: 'pagination',
-            default: true,
-            active: true
-        },
-        invalid: 'defaults'
+  query: {
+    page: {
+      name: 'page',
+      default: 1
     },
-    meta: {
-        location: 'body',
-        successStatusCode: undefined,
-        baseUri: undefined,
-        name: 'meta',
-        count: {
-            active: true,
-            name: 'count'
-        },
-        totalCount: {
-            active: true,
-            name: 'totalCount'
-        },
-        pageCount: {
-            active: true,
-            name: 'pageCount'
-        },
-        self: {
-            active: true,
-            name: 'self'
-        },
-        previous: {
-            active: true,
-            name: 'previous'
-        },
-        next: {
-            active: true,
-            name: 'next'
-        },
-        hasNext: {
-            active: false,
-            name: 'hasNext'
-        },
-        hasPrevious: {
-            active: false,
-            name: 'hasPrevious'
-        },
-        first: {
-            active: true,
-            name: 'first'
-        },
-        last: {
-            active: true,
-            name: 'last'
-        },
-
-        // name == default.query.page.name
-        page: {
-            active: false
-        },
-
-        // name == default.query.limit.name
-        limit: {
-            active: false
-        }
+    limit: {
+      name: 'limit',
+      default: 25
     },
-    results: {
+    pagination: {
+      name: 'pagination',
+      default: true,
+      active: true
+    },
+    invalid: 'defaults'
+  },
+  meta: {
+    location: 'body',
+    successStatusCode: undefined,
+    baseUri: undefined,
+    name: 'meta',
+    count: {
+      active: true,
+      name: 'count'
+    },
+    totalCount: {
+      active: true,
+      name: 'totalCount'
+    },
+    pageCount: {
+      active: true,
+      name: 'pageCount'
+    },
+    self: {
+      active: true,
+      name: 'self'
+    },
+    previous: {
+      active: true,
+      name: 'previous'
+    },
+    next: {
+      active: true,
+      name: 'next'
+    },
+    hasNext: {
+      active: false,
+      name: 'hasNext'
+    },
+    hasPrevious: {
+      active: false,
+      name: 'hasPrevious'
+    },
+    first: {
+      active: true,
+      name: 'first'
+    },
+    last: {
+      active: true,
+      name: 'last'
+    },
+
+    // name == default.query.page.name
+    page: {
+      active: false
+    },
+
+    // name == default.query.limit.name
+    limit: {
+      active: false
+    }
+  },
+  results: {
+    name: 'results'
+  },
+  reply: {
+    paginate: 'paginate',
+    parameters: {
+      results: {
         name: 'results'
-    },
-    reply: {
-        paginate: 'paginate',
-        parameters: {
-            results: {
-                name: 'results'
-            },
-            totalCount: {
-                name: 'totalCount'
-            }
-        }
-    },
-    routes: {
-        include: ['*'],
-        exclude: []
-    },
-    zeroIndex: false
-};
+      },
+      totalCount: {
+        name: 'totalCount'
+      }
+    }
+  },
+  routes: {
+    include: ['*'],
+    exclude: []
+  },
+  zeroIndex: false
+}

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -6,27 +6,21 @@ const Hoek = require('@hapi/hoek');
 const Qs = require('querystring');
 
 module.exports = class Ext {
-
     constructor(config) {
-
         this.config = config;
     }
 
     getRouteOptions(request) {
-
         return request.route.settings.plugins.pagination || {};
     }
 
     containsPath(array, path) {
-
         return Utils.some(array, (item) => {
-
             return item instanceof RegExp ? item.test(path) : item === path;
         });
     }
 
     isValidRoute(request) {
-
         const include = this.config.routes.include;
         const exclude = this.config.routes.exclude;
         const options = this.getRouteOptions(request);
@@ -38,14 +32,13 @@ module.exports = class Ext {
         }
 
         return (
-            (method === 'get') &&
+            method === 'get' &&
             (include[0] === '*' || this.containsPath(include, path)) &&
-            (!this.containsPath(exclude, path))
+            !this.containsPath(exclude, path)
         );
     }
 
     getPagination(request) {
-
         if (this.config.query.pagination.active) {
             const pagination = request.query[this.config.query.pagination.name];
 
@@ -68,22 +61,18 @@ module.exports = class Ext {
     }
 
     name(arg) {
-
         return this.config.meta[arg].name;
     }
 
     assignIfActive(meta, name, value) {
-
         if (this.config.meta[name].active) {
             meta[this.name(name)] = value;
         }
     }
 
     onPreHandler(request, h) {
-
         // If the route does not match, just skip this part
         if (this.isValidRoute(request)) {
-
             const routeDefaults = this.getRouteOptions(request).defaults || {};
             const pagination = this.getPagination(request);
             request.query[this.config.query.pagination.name] = pagination;
@@ -93,10 +82,10 @@ module.exports = class Ext {
             }
 
             const page = routeDefaults.page || this.config.query.page.default;
-            const limit = routeDefaults.limit || this.config.query.limit.default;
+            const limit =
+                routeDefaults.limit || this.config.query.limit.default;
 
             const setParam = (arg, defaultValue) => {
-
                 const name = this.name(arg);
                 let value = null;
 
@@ -106,9 +95,8 @@ module.exports = class Ext {
                     if (Utils.isNaN(value)) {
                         if (this.config.query.invalid === 'defaults') {
                             value = this.config.query[arg].default;
-                        }
-                        else {
-                            return h.response({ message: 'Invalid ' + name });
+                        } else {
+                            return h.response({ message: `Invalid ${name}` });
                         }
                     }
                 }
@@ -129,10 +117,9 @@ module.exports = class Ext {
         }
 
         return h.continue;
-    };
+    }
 
     onPostHandler(request, h) {
-
         const statusCode = request.response.statusCode;
         const processResponse =
             this.isValidRoute(request) &&
@@ -151,15 +138,19 @@ module.exports = class Ext {
         }
 
         const source = request.response.source;
-        const results = Array.isArray(source) ? source : source[this.config.reply.parameters.results.name];
+        const results = Array.isArray(source)
+            ? source
+            : source[this.config.reply.parameters.results.name];
         Hoek.assert(Array.isArray(results), 'The results must be an array');
 
-        const baseUri = this.config.uri + request.url.pathname + '?';
+        const baseUri = `${this.config.uri + request.url.pathname}?`;
         const query = request.query; // Query parameters
         const currentPage = query[this.config.query.page.name];
         const currentLimit = query[this.config.query.limit.name];
 
-        const totalCount = Utils.isUndefined(source[this.config.reply.parameters.totalCount.name])
+        const totalCount = Utils.isUndefined(
+            source[this.config.reply.parameters.totalCount.name]
+        )
             ? Utils.isUndefined(request.response.headers['total-count'])
                 ? request[this.config.meta.totalCount.name]
                 : request.response.headers['total-count']
@@ -168,11 +159,11 @@ module.exports = class Ext {
         let pageCount = null;
         if (!Utils.isNil(totalCount)) {
             pageCount =
-                Math.trunc(totalCount / currentLimit) + (totalCount % currentLimit === 0 ? 0 : 1);
+                Math.trunc(totalCount / currentLimit) +
+                (totalCount % currentLimit === 0 ? 0 : 1);
         }
 
         const getUri = (page) => {
-
             if (!page) {
                 return null;
             }
@@ -188,8 +179,12 @@ module.exports = class Ext {
         };
 
         const meta = {};
-        const hasNext = !Utils.isNil(totalCount) && totalCount !== 0 && currentPage < pageCount;
-        const hasPrevious = !Utils.isNil(totalCount) && totalCount !== 0 && currentPage > 1;
+        const hasNext =
+            !Utils.isNil(totalCount) &&
+            totalCount !== 0 &&
+            currentPage < pageCount;
+        const hasPrevious =
+            !Utils.isNil(totalCount) && totalCount !== 0 && currentPage > 1;
 
         if (this.config.meta.location === 'header') {
             delete request.response.headers['total-count'];
@@ -200,19 +195,20 @@ module.exports = class Ext {
                 const endIndex = startIndex + results.length - 1;
 
                 const links = [];
-                links.push('<' + getUri(currentPage) + '>; rel="self"');
-                links.push('<' + getUri(1) + '>; rel="first"');
-                links.push('<' + getUri(pageCount) + '>; rel="last"');
+                links.push(`<${getUri(currentPage)}>; rel="self"`);
+                links.push(`<${getUri(1)}>; rel="first"`);
+                links.push(`<${getUri(pageCount)}>; rel="last"`);
 
                 if (hasNext) {
-                    links.push('<' + getUri(currentPage + 1) + '>; rel="next"');
+                    links.push(`<${getUri(currentPage + 1)}>; rel="next"`);
                 }
 
                 if (hasPrevious) {
-                    links.push('<' + getUri(currentPage - 1) + '>; rel="prev"');
+                    links.push(`<${getUri(currentPage - 1)}>; rel="prev"`);
                 }
 
-                request.response.headers['Content-Range'] = startIndex + '-' + endIndex + '/' + totalCount;
+                request.response.headers['Content-Range'] =
+                    `${startIndex}-${endIndex}/${totalCount}`;
                 request.response.headers.Link = links;
 
                 if (this.config.meta.successStatusCode) {
@@ -221,16 +217,23 @@ module.exports = class Ext {
             }
 
             request.response.source = results;
-        }
-        else {
+        } else {
             this.assignIfActive(meta, 'page', query[this.name('page')]);
             this.assignIfActive(meta, 'limit', query[this.name('limit')]);
 
             this.assignIfActive(meta, 'count', results.length);
             this.assignIfActive(meta, 'pageCount', pageCount);
-            this.assignIfActive(meta, 'totalCount', Utils.isNil(totalCount) ? null : totalCount);
+            this.assignIfActive(
+                meta,
+                'totalCount',
+                Utils.isNil(totalCount) ? null : totalCount
+            );
 
-            this.assignIfActive(meta, 'next', hasNext ? getUri(currentPage + 1) : null);
+            this.assignIfActive(
+                meta,
+                'next',
+                hasNext ? getUri(currentPage + 1) : null
+            );
             this.assignIfActive(meta, 'previous', getUri(currentPage - 1));
             this.assignIfActive(meta, 'hasNext', hasNext);
             this.assignIfActive(meta, 'hasPrevious', hasPrevious);
@@ -238,7 +241,6 @@ module.exports = class Ext {
             this.assignIfActive(meta, 'self', getUri(currentPage));
             this.assignIfActive(meta, 'first', getUri(1));
             this.assignIfActive(meta, 'last', getUri(pageCount));
-
 
             const newSource = {
                 [this.config.meta.name]: meta,
@@ -248,13 +250,14 @@ module.exports = class Ext {
             if (source.response) {
                 const keys = Object.keys(source.response);
 
-                for (let i = 0; i < keys.length; ++i) {
-                    const key = keys[i];
-                    if (key !== this.config.meta.name &&
-                        key !== this.config.results.name) {
+                keys.forEach(key => {
+                    if (
+                        key !== this.config.meta.name &&
+                        key !== this.config.results.name
+                    ) {
                         newSource[key] = source.response[key];
                     }
-                }
+                });
             }
 
             if (this.config.meta.successStatusCode) {

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -14,8 +14,8 @@ module.exports = class Ext {
     return request.route.settings.plugins.pagination || {}
   }
 
-  containsPath(array, path) {
-    return Utils.some(array, (item) => {
+  containsPath(paths, path) {
+    return paths.some(item => {
       return item instanceof RegExp ? item.test(path) : item === path
     })
   }
@@ -91,7 +91,7 @@ module.exports = class Ext {
       const name = this.name(arg)
       let value = null
 
-      if (request.query[name] != null) {
+      if (!Utils.isNil(request.query[name])) {
         value = parseInt(request.query[name])
 
         if (Utils.isNaN(value)) {
@@ -103,7 +103,7 @@ module.exports = class Ext {
         }
       }
 
-      request.query[name] = value != null ? value : defaultValue
+      request.query[name] = Utils.isNaN(value) ? defaultValue : value;
       return null
     }
 
@@ -143,12 +143,12 @@ module.exports = class Ext {
       : source[this.config.reply.parameters.results.name]
     Hoek.assert(Array.isArray(results), 'The results must be an array')
 
-    const baseUri = `${this.config.uri + request.url.pathname}?`
+    const baseUri = `${this.config.uri}${request.url.pathname}?`
     const query = request.query // Query parameters
     const currentPage = query[this.config.query.page.name]
     const currentLimit = query[this.config.query.limit.name]
     const { zeroIndex } = this.config
-    const pageIndex = zeroIndex ? 0 : 1
+    const firstPage = zeroIndex ? 0 : 1
 
     const totalCount = Utils.isUndefined(
       source[this.config.reply.parameters.totalCount.name]
@@ -185,19 +185,19 @@ module.exports = class Ext {
     const hasNext =
       !Utils.isNil(totalCount) && totalCount !== 0 && currentPage < maxPage
     const hasPrevious =
-      !Utils.isNil(totalCount) && totalCount !== 0 && currentPage > pageIndex
+      !Utils.isNil(totalCount) && totalCount !== 0 && currentPage > firstPage
 
     if (this.config.meta.location === 'header') {
       delete request.response.headers['total-count']
 
       if (totalCount > currentLimit && results.length > 0) {
         // put metadata in headers rather than in body
-        const startIndex = currentLimit * (currentPage - pageIndex)
-        const endIndex = startIndex + results.length - pageIndex
+        const startIndex = currentLimit * (currentPage - firstPage)
+        const endIndex = startIndex + results.length - firstPage
 
         const links = []
         links.push(`<${getUri(currentPage)}>; rel="self"`)
-        links.push(`<${getUri(pageIndex)}>; rel="first"`)
+        links.push(`<${getUri(firstPage)}>; rel="first"`)
         links.push(`<${getUri(pageCount)}>; rel="last"`)
 
         if (hasNext) {
@@ -245,7 +245,7 @@ module.exports = class Ext {
       this.assignIfActive(meta, 'hasPrevious', hasPrevious)
 
       this.assignIfActive(meta, 'self', getUri(currentPage))
-      this.assignIfActive(meta, 'first', getUri(pageIndex))
+      this.assignIfActive(meta, 'first', getUri(firstPage))
       this.assignIfActive(
         meta,
         'last',

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -1,286 +1,282 @@
-'use strict';
+'use strict'
 
-const Utils = require('./utils');
-const Boom = require('@hapi/boom');
-const Hoek = require('@hapi/hoek');
-const Qs = require('querystring');
+const Utils = require('./utils')
+const Boom = require('@hapi/boom')
+const Hoek = require('@hapi/hoek')
+const Qs = require('querystring')
 
 module.exports = class Ext {
-    constructor(config) {
-        this.config = config;
+  constructor(config) {
+    this.config = config
+  }
+
+  getRouteOptions(request) {
+    return request.route.settings.plugins.pagination || {}
+  }
+
+  containsPath(array, path) {
+    return Utils.some(array, (item) => {
+      return item instanceof RegExp ? item.test(path) : item === path
+    })
+  }
+
+  isValidRoute(request) {
+    const include = this.config.routes.include
+    const exclude = this.config.routes.exclude
+    const options = this.getRouteOptions(request)
+    const path = request.route.path
+    const method = request.route.method
+
+    if (!Utils.isUndefined(options.enabled)) {
+      return options.enabled
     }
 
-    getRouteOptions(request) {
-        return request.route.settings.plugins.pagination || {};
+    return (
+      method === 'get' &&
+      (include[0] === '*' || this.containsPath(include, path)) &&
+      !this.containsPath(exclude, path)
+    )
+  }
+
+  getPagination(request) {
+    if (this.config.query.pagination.active) {
+      const pagination = request.query[this.config.query.pagination.name]
+
+      if (pagination === 'false' || pagination === false) {
+        return false
+      }
+
+      if (pagination === 'true' || pagination === true) {
+        return true
+      }
     }
 
-    containsPath(array, path) {
-        return Utils.some(array, (item) => {
-            return item instanceof RegExp ? item.test(path) : item === path;
-        });
+    const routeDefaults = this.getRouteOptions(request).defaults || {}
+
+    if (!Utils.isUndefined(routeDefaults.pagination)) {
+      return routeDefaults.pagination
     }
 
-    isValidRoute(request) {
-        const include = this.config.routes.include;
-        const exclude = this.config.routes.exclude;
-        const options = this.getRouteOptions(request);
-        const path = request.route.path;
-        const method = request.route.method;
+    return this.config.query.pagination.default
+  }
 
-        if (!Utils.isUndefined(options.enabled)) {
-            return options.enabled;
-        }
+  name(arg) {
+    return this.config.meta[arg].name
+  }
 
-        return (
-            method === 'get' &&
-            (include[0] === '*' || this.containsPath(include, path)) &&
-            !this.containsPath(exclude, path)
-        );
+  assignIfActive(meta, name, value) {
+    if (this.config.meta[name].active) {
+      meta[this.name(name)] = value
+    }
+  }
+
+  onPreHandler(request, h) {
+    // If the route does not match, just skip this part
+    if (!this.isValidRoute(request)) {
+      return h.continue
     }
 
-    getPagination(request) {
-        if (this.config.query.pagination.active) {
-            const pagination = request.query[this.config.query.pagination.name];
+    const routeDefaults = this.getRouteOptions(request).defaults || {}
+    const pagination = this.getPagination(request)
+    request.query[this.config.query.pagination.name] = pagination
 
-            if (pagination === 'false' || pagination === false) {
-                return false;
-            }
-
-            if (pagination === 'true' || pagination === true) {
-                return true;
-            }
-        }
-
-        const routeDefaults = this.getRouteOptions(request).defaults || {};
-
-        if (!Utils.isUndefined(routeDefaults.pagination)) {
-            return routeDefaults.pagination;
-        }
-
-        return this.config.query.pagination.default;
+    if (pagination === false) {
+      return h.continue
     }
 
-    name(arg) {
-        return this.config.meta[arg].name;
+    const page = routeDefaults.page || this.config.query.page.default
+    const limit = routeDefaults.limit || this.config.query.limit.default
+
+    const setParam = (arg, defaultValue) => {
+      const name = this.name(arg)
+      let value = null
+
+      if (request.query[name] != null) {
+        value = parseInt(request.query[name])
+
+        if (Utils.isNaN(value)) {
+          if (this.config.query.invalid === 'defaults') {
+            value = this.config.query[arg].default
+          } else {
+            return h.response({ message: `Invalid ${name}` })
+          }
+        }
+      }
+
+      request.query[name] = value != null ? value : defaultValue
+      return null
     }
 
-    assignIfActive(meta, name, value) {
-        if (this.config.meta[name].active) {
-            meta[this.name(name)] = value;
-        }
+    let err = setParam('page', page)
+
+    if (!err) {
+      err = setParam('limit', limit)
     }
 
-    onPreHandler(request, h) {
-        // If the route does not match, just skip this part
-        if (!this.isValidRoute(request)) {
-            return h.continue;
-        }
+    if (err) {
+      return Boom.badRequest(err.message)
+    }
+    return h.continue
+  }
 
-        const routeDefaults = this.getRouteOptions(request).defaults || {};
-        const pagination = this.getPagination(request);
-        request.query[this.config.query.pagination.name] = pagination;
+  onPostHandler(request, h) {
+    const statusCode = request.response.statusCode
+    const processResponse =
+      this.isValidRoute(request) &&
+      statusCode >= 200 &&
+      statusCode <= 299 &&
+      this.getPagination(request)
 
-        if (pagination === false) {
-            return h.continue;
-        }
-
-        const page = routeDefaults.page || this.config.query.page.default;
-        const limit = routeDefaults.limit || this.config.query.limit.default;
-
-        const setParam = (arg, defaultValue) => {
-            const name = this.name(arg);
-            let value = null;
-
-            if (request.query[name] != null) {
-                value = parseInt(request.query[name]);
-
-                if (Utils.isNaN(value)) {
-                    if (this.config.query.invalid === 'defaults') {
-                        value = this.config.query[arg].default;
-                    } else {
-                        return h.response({ message: `Invalid ${name}` });
-                    }
-                }
-            }
-
-            request.query[name] = value != null ? value : defaultValue;
-            return null;
-        };
-
-        let err = setParam('page', page);
-
-        if (!err) {
-            err = setParam('limit', limit);
-        }
-
-        if (err) {
-            return Boom.badRequest(err.message);
-        }
-        return h.continue;
+    if (!processResponse) {
+      return h.continue
     }
 
-    onPostHandler(request, h) {
-        const statusCode = request.response.statusCode;
-        const processResponse =
-            this.isValidRoute(request) &&
-            statusCode >= 200 &&
-            statusCode <= 299 &&
-            this.getPagination(request);
-
-        if (!processResponse) {
-            return h.continue;
-        }
-
-        // Removes pagination from query parameters if default is true
-        // If defaults is false, pagination param is needed in the generated links
-        if (this.config.query.pagination.default) {
-            delete request.query[this.config.query.pagination.name];
-        }
-
-        const source = request.response.source;
-        const results = Array.isArray(source)
-            ? source
-            : source[this.config.reply.parameters.results.name];
-        Hoek.assert(Array.isArray(results), 'The results must be an array');
-
-        const baseUri = `${this.config.uri + request.url.pathname}?`;
-        const query = request.query; // Query parameters
-        const currentPage = query[this.config.query.page.name];
-        const currentLimit = query[this.config.query.limit.name];
-        const { zeroIndex } = this.config;
-        const pageIndex = zeroIndex ? 0 : 1;
-
-        const totalCount = Utils.isUndefined(
-            source[this.config.reply.parameters.totalCount.name]
-        )
-            ? Utils.isUndefined(request.response.headers['total-count'])
-                ? request[this.config.meta.totalCount.name]
-                : request.response.headers['total-count']
-            : source[this.config.reply.parameters.totalCount.name];
-
-        let pageCount = null;
-        if (!Utils.isNil(totalCount)) {
-            pageCount =
-                Math.trunc(totalCount / currentLimit) +
-                (totalCount % currentLimit === 0 ? 0 : 1);
-        }
-
-        const getUri = (page) => {
-            if (!page && page !== 0) {
-                return null;
-            }
-
-            const origQuery = Object.assign({}, query, request.orig.query);
-
-            // Override page
-            const qs = Hoek.applyToDefaults(origQuery, {
-                [this.config.query.page.name]: page
-            });
-
-            return baseUri + Qs.stringify(qs);
-        };
-
-        const maxPage = zeroIndex ? pageCount - 1 : pageCount;
-        const meta = {};
-        const hasNext =
-            !Utils.isNil(totalCount) &&
-            totalCount !== 0 &&
-            currentPage < maxPage;
-        const hasPrevious =
-            !Utils.isNil(totalCount) &&
-            totalCount !== 0 &&
-            currentPage > pageIndex;
-
-        if (this.config.meta.location === 'header') {
-            delete request.response.headers['total-count'];
-
-            if (totalCount > currentLimit && results.length > 0) {
-                // put metadata in headers rather than in body
-                const startIndex = currentLimit * (currentPage - pageIndex);
-                const endIndex = startIndex + results.length - pageIndex;
-
-                const links = [];
-                links.push(`<${getUri(currentPage)}>; rel="self"`);
-                links.push(`<${getUri(pageIndex)}>; rel="first"`);
-                links.push(`<${getUri(pageCount)}>; rel="last"`);
-
-                if (hasNext) {
-                    links.push(`<${getUri(currentPage + 1)}>; rel="next"`);
-                }
-
-                if (hasPrevious) {
-                    links.push(`<${getUri(currentPage - 1)}>; rel="prev"`);
-                }
-
-                request.response.headers[
-                    'Content-Range'
-                ] = `${startIndex}-${endIndex}/${totalCount}`;
-                request.response.headers.Link = links;
-
-                if (this.config.meta.successStatusCode) {
-                    request.response.code(this.config.meta.successStatusCode);
-                }
-            }
-
-            request.response.source = results;
-        } else {
-            this.assignIfActive(meta, 'page', query[this.name('page')]);
-            this.assignIfActive(meta, 'limit', query[this.name('limit')]);
-
-            this.assignIfActive(meta, 'count', results.length);
-            this.assignIfActive(meta, 'pageCount', pageCount);
-            this.assignIfActive(
-                meta,
-                'totalCount',
-                Utils.isNil(totalCount) ? null : totalCount
-            );
-
-            this.assignIfActive(
-                meta,
-                'next',
-                hasNext ? getUri(currentPage + 1) : null
-            );
-            this.assignIfActive(
-                meta,
-                'previous',
-                hasPrevious ? getUri(currentPage - 1) : null
-            );
-            this.assignIfActive(meta, 'hasNext', hasNext);
-            this.assignIfActive(meta, 'hasPrevious', hasPrevious);
-
-            this.assignIfActive(meta, 'self', getUri(currentPage));
-            this.assignIfActive(meta, 'first', getUri(pageIndex));
-            this.assignIfActive(
-                meta,
-                'last',
-                getUri(!zeroIndex ? pageCount : pageCount - 1)
-            );
-
-            const newSource = {
-                [this.config.meta.name]: meta,
-                [this.config.results.name]: results
-            };
-
-            if (source.response) {
-                const keys = Object.keys(source.response);
-
-                keys.forEach((key) => {
-                    if (
-                        key !== this.config.meta.name &&
-                        key !== this.config.results.name
-                    ) {
-                        newSource[key] = source.response[key];
-                    }
-                });
-            }
-
-            if (this.config.meta.successStatusCode) {
-                request.response.code(this.config.meta.successStatusCode);
-            }
-
-            request.response.source = newSource;
-        }
-
-        return h.continue;
+    // Removes pagination from query parameters if default is true
+    // If defaults is false, pagination param is needed in the generated links
+    if (this.config.query.pagination.default) {
+      delete request.query[this.config.query.pagination.name]
     }
-};
+
+    const source = request.response.source
+    const results = Array.isArray(source)
+      ? source
+      : source[this.config.reply.parameters.results.name]
+    Hoek.assert(Array.isArray(results), 'The results must be an array')
+
+    const baseUri = `${this.config.uri + request.url.pathname}?`
+    const query = request.query // Query parameters
+    const currentPage = query[this.config.query.page.name]
+    const currentLimit = query[this.config.query.limit.name]
+    const { zeroIndex } = this.config
+    const pageIndex = zeroIndex ? 0 : 1
+
+    const totalCount = Utils.isUndefined(
+      source[this.config.reply.parameters.totalCount.name]
+    )
+      ? Utils.isUndefined(request.response.headers['total-count'])
+        ? request[this.config.meta.totalCount.name]
+        : request.response.headers['total-count']
+      : source[this.config.reply.parameters.totalCount.name]
+
+    let pageCount = null
+    if (!Utils.isNil(totalCount)) {
+      pageCount =
+        Math.trunc(totalCount / currentLimit) +
+        (totalCount % currentLimit === 0 ? 0 : 1)
+    }
+
+    const getUri = (page) => {
+      if (!page && page !== 0) {
+        return null
+      }
+
+      const origQuery = Object.assign({}, query, request.orig.query)
+
+      // Override page
+      const qs = Hoek.applyToDefaults(origQuery, {
+        [this.config.query.page.name]: page
+      })
+
+      return baseUri + Qs.stringify(qs)
+    }
+
+    const maxPage = zeroIndex ? pageCount - 1 : pageCount
+    const meta = {}
+    const hasNext =
+      !Utils.isNil(totalCount) && totalCount !== 0 && currentPage < maxPage
+    const hasPrevious =
+      !Utils.isNil(totalCount) && totalCount !== 0 && currentPage > pageIndex
+
+    if (this.config.meta.location === 'header') {
+      delete request.response.headers['total-count']
+
+      if (totalCount > currentLimit && results.length > 0) {
+        // put metadata in headers rather than in body
+        const startIndex = currentLimit * (currentPage - pageIndex)
+        const endIndex = startIndex + results.length - pageIndex
+
+        const links = []
+        links.push(`<${getUri(currentPage)}>; rel="self"`)
+        links.push(`<${getUri(pageIndex)}>; rel="first"`)
+        links.push(`<${getUri(pageCount)}>; rel="last"`)
+
+        if (hasNext) {
+          links.push(`<${getUri(currentPage + 1)}>; rel="next"`)
+        }
+
+        if (hasPrevious) {
+          links.push(`<${getUri(currentPage - 1)}>; rel="prev"`)
+        }
+
+        request.response.headers[
+          'Content-Range'
+        ] = `${startIndex}-${endIndex}/${totalCount}`
+        request.response.headers.Link = links
+
+        if (this.config.meta.successStatusCode) {
+          request.response.code(this.config.meta.successStatusCode)
+        }
+      }
+
+      request.response.source = results
+    } else {
+      this.assignIfActive(meta, 'page', query[this.name('page')])
+      this.assignIfActive(meta, 'limit', query[this.name('limit')])
+
+      this.assignIfActive(meta, 'count', results.length)
+      this.assignIfActive(meta, 'pageCount', pageCount)
+      this.assignIfActive(
+        meta,
+        'totalCount',
+        Utils.isNil(totalCount) ? null : totalCount
+      )
+
+      this.assignIfActive(
+        meta,
+        'next',
+        hasNext ? getUri(currentPage + 1) : null
+      )
+      this.assignIfActive(
+        meta,
+        'previous',
+        hasPrevious ? getUri(currentPage - 1) : null
+      )
+      this.assignIfActive(meta, 'hasNext', hasNext)
+      this.assignIfActive(meta, 'hasPrevious', hasPrevious)
+
+      this.assignIfActive(meta, 'self', getUri(currentPage))
+      this.assignIfActive(meta, 'first', getUri(pageIndex))
+      this.assignIfActive(
+        meta,
+        'last',
+        getUri(!zeroIndex ? pageCount : pageCount - 1)
+      )
+
+      const newSource = {
+        [this.config.meta.name]: meta,
+        [this.config.results.name]: results
+      }
+
+      if (source.response) {
+        const keys = Object.keys(source.response)
+
+        keys.forEach((key) => {
+          if (
+            key !== this.config.meta.name &&
+            key !== this.config.results.name
+          ) {
+            newSource[key] = source.response[key]
+          }
+        })
+      }
+
+      if (this.config.meta.successStatusCode) {
+        request.response.code(this.config.meta.successStatusCode)
+      }
+
+      request.response.source = newSource
+    }
+
+    return h.continue
+  }
+}

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -72,50 +72,50 @@ module.exports = class Ext {
 
     onPreHandler(request, h) {
         // If the route does not match, just skip this part
-        if (this.isValidRoute(request)) {
-            const routeDefaults = this.getRouteOptions(request).defaults || {};
-            const pagination = this.getPagination(request);
-            request.query[this.config.query.pagination.name] = pagination;
-
-            if (pagination === false) {
-                return h.continue;
-            }
-
-            const page = routeDefaults.page || this.config.query.page.default;
-            const limit =
-                routeDefaults.limit || this.config.query.limit.default;
-
-            const setParam = (arg, defaultValue) => {
-                const name = this.name(arg);
-                let value = null;
-
-                if (request.query[name]) {
-                    value = parseInt(request.query[name]);
-
-                    if (Utils.isNaN(value)) {
-                        if (this.config.query.invalid === 'defaults') {
-                            value = this.config.query[arg].default;
-                        } else {
-                            return h.response({ message: `Invalid ${name}` });
-                        }
-                    }
-                }
-
-                request.query[name] = value || defaultValue;
-                return null;
-            };
-
-            let err = setParam('page', page);
-
-            if (!err) {
-                err = setParam('limit', limit);
-            }
-
-            if (err) {
-                return Boom.badRequest(err.message);
-            }
+        if (!this.isValidRoute(request)) {
+            return h.continue;
         }
 
+        const routeDefaults = this.getRouteOptions(request).defaults || {};
+        const pagination = this.getPagination(request);
+        request.query[this.config.query.pagination.name] = pagination;
+
+        if (pagination === false) {
+            return h.continue;
+        }
+
+        const page = routeDefaults.page || this.config.query.page.default;
+        const limit = routeDefaults.limit || this.config.query.limit.default;
+
+        const setParam = (arg, defaultValue) => {
+            const name = this.name(arg);
+            let value = null;
+
+            if (request.query[name] != null) {
+                value = parseInt(request.query[name]);
+
+                if (Utils.isNaN(value)) {
+                    if (this.config.query.invalid === 'defaults') {
+                        value = this.config.query[arg].default;
+                    } else {
+                        return h.response({ message: `Invalid ${name}` });
+                    }
+                }
+            }
+
+            request.query[name] = value != null ? value : defaultValue;
+            return null;
+        };
+
+        let err = setParam('page', page);
+
+        if (!err) {
+            err = setParam('limit', limit);
+        }
+
+        if (err) {
+            return Boom.badRequest(err.message);
+        }
         return h.continue;
     }
 
@@ -132,7 +132,7 @@ module.exports = class Ext {
         }
 
         // Removes pagination from query parameters if default is true
-        // If defaults is false, paginaton param is needed in the generated links
+        // If defaults is false, pagination param is needed in the generated links
         if (this.config.query.pagination.default) {
             delete request.query[this.config.query.pagination.name];
         }
@@ -147,6 +147,8 @@ module.exports = class Ext {
         const query = request.query; // Query parameters
         const currentPage = query[this.config.query.page.name];
         const currentLimit = query[this.config.query.limit.name];
+        const { zeroIndex } = this.config;
+        const pageIndex = zeroIndex ? 0 : 1;
 
         const totalCount = Utils.isUndefined(
             source[this.config.reply.parameters.totalCount.name]
@@ -164,7 +166,7 @@ module.exports = class Ext {
         }
 
         const getUri = (page) => {
-            if (!page) {
+            if (!page && page !== 0) {
                 return null;
             }
 
@@ -178,25 +180,28 @@ module.exports = class Ext {
             return baseUri + Qs.stringify(qs);
         };
 
+        const maxPage = zeroIndex ? pageCount - 1 : pageCount;
         const meta = {};
         const hasNext =
             !Utils.isNil(totalCount) &&
             totalCount !== 0 &&
-            currentPage < pageCount;
+            currentPage < maxPage;
         const hasPrevious =
-            !Utils.isNil(totalCount) && totalCount !== 0 && currentPage > 1;
+            !Utils.isNil(totalCount) &&
+            totalCount !== 0 &&
+            currentPage > pageIndex;
 
         if (this.config.meta.location === 'header') {
             delete request.response.headers['total-count'];
 
             if (totalCount > currentLimit && results.length > 0) {
                 // put metadata in headers rather than in body
-                const startIndex = currentLimit * (currentPage - 1);
-                const endIndex = startIndex + results.length - 1;
+                const startIndex = currentLimit * (currentPage - pageIndex);
+                const endIndex = startIndex + results.length - pageIndex;
 
                 const links = [];
                 links.push(`<${getUri(currentPage)}>; rel="self"`);
-                links.push(`<${getUri(1)}>; rel="first"`);
+                links.push(`<${getUri(pageIndex)}>; rel="first"`);
                 links.push(`<${getUri(pageCount)}>; rel="last"`);
 
                 if (hasNext) {
@@ -207,8 +212,9 @@ module.exports = class Ext {
                     links.push(`<${getUri(currentPage - 1)}>; rel="prev"`);
                 }
 
-                request.response.headers['Content-Range'] =
-                    `${startIndex}-${endIndex}/${totalCount}`;
+                request.response.headers[
+                    'Content-Range'
+                ] = `${startIndex}-${endIndex}/${totalCount}`;
                 request.response.headers.Link = links;
 
                 if (this.config.meta.successStatusCode) {
@@ -234,13 +240,21 @@ module.exports = class Ext {
                 'next',
                 hasNext ? getUri(currentPage + 1) : null
             );
-            this.assignIfActive(meta, 'previous', getUri(currentPage - 1));
+            this.assignIfActive(
+                meta,
+                'previous',
+                hasPrevious ? getUri(currentPage - 1) : null
+            );
             this.assignIfActive(meta, 'hasNext', hasNext);
             this.assignIfActive(meta, 'hasPrevious', hasPrevious);
 
             this.assignIfActive(meta, 'self', getUri(currentPage));
-            this.assignIfActive(meta, 'first', getUri(1));
-            this.assignIfActive(meta, 'last', getUri(pageCount));
+            this.assignIfActive(meta, 'first', getUri(pageIndex));
+            this.assignIfActive(
+                meta,
+                'last',
+                getUri(!zeroIndex ? pageCount : pageCount - 1)
+            );
 
             const newSource = {
                 [this.config.meta.name]: meta,
@@ -250,7 +264,7 @@ module.exports = class Ext {
             if (source.response) {
                 const keys = Object.keys(source.response);
 
-                keys.forEach(key => {
+                keys.forEach((key) => {
                     if (
                         key !== this.config.meta.name &&
                         key !== this.config.results.name

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,6 @@ exports.plugin = {
     pkg: require('../package.json'),
     name: 'hapi-pagination',
     register: function (server, options) {
-
         const result = Config.getConfig(server, options);
 
         if (result.error) {
@@ -21,15 +20,21 @@ exports.plugin = {
         config.meta.limit.name = config.query.limit.name;
 
         // Sets uri for generated link
-        config.uri = typeof config.meta.baseUri !== 'undefined' ? config.meta.baseUri : server.info.uri;
+        config.uri =
+            typeof config.meta.baseUri !== 'undefined'
+                ? config.meta.baseUri
+                : server.info.uri;
 
         const decorate = require('./decorate')(config);
         const ext = new Ext(config);
 
         try {
-            server.decorate('toolkit', config.reply.paginate, decorate.paginate);
-        }
-        catch (err) {
+            server.decorate(
+                'toolkit',
+                config.reply.paginate,
+                decorate.paginate
+            );
+        } catch (err) {
             // Decoration can be defined once for the entire server.
             // Error: Reply interface decoration already defined.
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,45 +1,41 @@
-'use strict';
+'use strict'
 
-const Config = require('./config');
-const Ext = require('./ext');
+const Config = require('./config')
+const Ext = require('./ext')
 
 exports.plugin = {
-    pkg: require('../package.json'),
-    name: 'hapi-pagination',
-    register: function (server, options) {
-        const result = Config.getConfig(server, options);
+  pkg: require('../package.json'),
+  name: 'hapi-pagination',
+  register: function (server, options) {
+    const result = Config.getConfig(server, options)
 
-        if (result.error) {
-            throw result.error;
-        }
-
-        const config = result.config;
-
-        // For simplicity
-        config.meta.page.name = config.query.page.name;
-        config.meta.limit.name = config.query.limit.name;
-
-        // Sets uri for generated link
-        config.uri =
-            typeof config.meta.baseUri !== 'undefined'
-                ? config.meta.baseUri
-                : server.info.uri;
-
-        const decorate = require('./decorate')(config);
-        const ext = new Ext(config);
-
-        try {
-            server.decorate(
-                'toolkit',
-                config.reply.paginate,
-                decorate.paginate
-            );
-        } catch (err) {
-            // Decoration can be defined once for the entire server.
-            // Error: Reply interface decoration already defined.
-        }
-
-        server.ext('onPreHandler', (s, h) => ext.onPreHandler(s, h));
-        server.ext('onPostHandler', (s, h) => ext.onPostHandler(s, h));
+    if (result.error) {
+      throw result.error
     }
-};
+
+    const config = result.config
+
+    // For simplicity
+    config.meta.page.name = config.query.page.name
+    config.meta.limit.name = config.query.limit.name
+
+    // Sets uri for generated link
+    config.uri =
+      typeof config.meta.baseUri !== 'undefined'
+        ? config.meta.baseUri
+        : server.info.uri
+
+    const decorate = require('./decorate')(config)
+    const ext = new Ext(config)
+
+    try {
+      server.decorate('toolkit', config.reply.paginate, decorate.paginate)
+    } catch (err) {
+      // Decoration can be defined once for the entire server.
+      // Error: Reply interface decoration already defined.
+    }
+
+    server.ext('onPreHandler', (s, h) => ext.onPreHandler(s, h))
+    server.ext('onPostHandler', (s, h) => ext.onPostHandler(s, h))
+  }
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,26 +10,6 @@ module.exports = exports = {
     return typeof value === 'undefined'
   },
 
-  some(collection, predicate) {
-    let bool = false
-    let index = -1
-
-    while (++index < collection.length && !bool) {
-      bool = predicate(collection[index], index, collection)
-    }
-
-    return bool
-  },
-
-  map(collection, fn) {
-    const result = []
-    for (const element of collection) {
-      result.push(fn(element))
-    }
-
-    return result
-  },
-
   // No need to check if a number, always used after a parse int (for now)
   isNaN(value) {
     return value !== +value

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,19 +2,15 @@
 
 // Some functions to replace lodash
 module.exports = exports = {
-
     isNil(value) {
-
         return typeof value === 'undefined' || value === null;
     },
 
     isUndefined(value) {
-
         return typeof value === 'undefined';
     },
 
     some(collection, predicate) {
-
         let bool = false;
         let index = -1;
 
@@ -26,7 +22,6 @@ module.exports = exports = {
     },
 
     map(collection, fn) {
-
         const result = [];
         for (const element of collection) {
             result.push(fn(element));
@@ -37,7 +32,6 @@ module.exports = exports = {
 
     // No need to check if a number, always used after a parse int (for now)
     isNaN(value) {
-
         return value !== +value;
     }
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,37 +1,37 @@
-'use strict';
+'use strict'
 
 // Some functions to replace lodash
 module.exports = exports = {
-    isNil(value) {
-        return typeof value === 'undefined' || value === null;
-    },
+  isNil(value) {
+    return typeof value === 'undefined' || value === null
+  },
 
-    isUndefined(value) {
-        return typeof value === 'undefined';
-    },
+  isUndefined(value) {
+    return typeof value === 'undefined'
+  },
 
-    some(collection, predicate) {
-        let bool = false;
-        let index = -1;
+  some(collection, predicate) {
+    let bool = false
+    let index = -1
 
-        while (++index < collection.length && !bool) {
-            bool = predicate(collection[index], index, collection);
-        }
-
-        return bool;
-    },
-
-    map(collection, fn) {
-        const result = [];
-        for (const element of collection) {
-            result.push(fn(element));
-        }
-
-        return result;
-    },
-
-    // No need to check if a number, always used after a parse int (for now)
-    isNaN(value) {
-        return value !== +value;
+    while (++index < collection.length && !bool) {
+      bool = predicate(collection[index], index, collection)
     }
-};
+
+    return bool
+  },
+
+  map(collection, fn) {
+    const result = []
+    for (const element of collection) {
+      result.push(fn(element))
+    }
+
+    return result
+  },
+
+  // No need to check if a number, always used after a parse int (for now)
+  isNaN(value) {
+    return value !== +value
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-pagination",
-  "version": "2.1.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-pagination",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A hapi plugin to paginate resources",
   "main": "lib/index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,7 @@
 
 const Code = require('@hapi/code');
 const Lab = require('@hapi/lab');
-const lab = exports.lab = Lab.script();
+const lab = (exports.lab = Lab.script());
 const Hapi = require('@hapi/hapi');
 const Joi = require('@hapi/joi');
 
@@ -20,8 +20,7 @@ for (let i = 0; i < 20; ++i) {
     });
 }
 
-const register = function () {
-
+const register = () => {
     const connection = { host: 'localhost' };
     const server = new Hapi.Server(connection);
 
@@ -41,18 +40,15 @@ const register = function () {
         method: 'GET',
         path: '/exception',
         handler: (request, h) => {
-
             throw new Error('test');
             return h.paginate([], 0);
         }
     });
 
-
     server.route({
         method: 'GET',
         path: '/users',
         handler: (request, h) => {
-
             const limit = request.query.limit;
             const page = request.query.page;
             const pagination = request.query.pagination;
@@ -60,7 +56,7 @@ const register = function () {
             const offset = limit * (page - 1);
             const response = [];
 
-            for (let i = offset; i < (offset + limit) && i < users.length; ++i) {
+            for (let i = offset; i < offset + limit && i < users.length; ++i) {
                 response.push(users[i]);
             }
 
@@ -72,12 +68,10 @@ const register = function () {
         }
     });
 
-
     server.route({
         method: 'GET',
         path: '/users2',
         handler: (request, h) => {
-
             const limit = request.query.limit;
             const page = request.query.page;
             const pagination = request.query.pagination;
@@ -85,14 +79,20 @@ const register = function () {
             const offset = limit * (page - 1);
             const response = [];
 
-            for (let i = offset; i < (offset + limit) && i < users.length; ++i) {
+            for (let i = offset; i < offset + limit && i < users.length; ++i) {
                 response.push(users[i]);
             }
 
             if (pagination) {
-                return h.paginate({ results: response, otherKey: 'otherKey', otherKey2: 'otherKey2' },
+                return h.paginate(
+                    {
+                        results: response,
+                        otherKey: 'otherKey',
+                        otherKey2: 'otherKey2'
+                    },
                     users.length,
-                    { key: 'results' });
+                    { key: 'results' }
+                );
             }
 
             return h.response(users);
@@ -103,7 +103,6 @@ const register = function () {
         method: 'GET',
         path: '/users3',
         handler: (request, h) => {
-
             const limit = request.query.limit;
             const page = request.query.page;
             const resultsKey = request.query.resultsKey;
@@ -116,7 +115,7 @@ const register = function () {
             response[resultsKey] = [];
             response[totalCountKey] = users.length;
 
-            for (let i = offset; i < (offset + limit) && i < users.length; ++i) {
+            for (let i = offset; i < offset + limit && i < users.length; ++i) {
                 response[resultsKey].push(users[i]);
             }
 
@@ -150,8 +149,6 @@ const register = function () {
         }
     });
 
-
-
     server.route({
         method: 'GET',
         path: '/defaults',
@@ -167,7 +164,6 @@ const register = function () {
             }
         },
         handler: (request, h) => {
-
             const limit = request.query.limit;
             const page = request.query.page;
             const pagination = request.query.pagination;
@@ -175,10 +171,9 @@ const register = function () {
             const offset = limit * (page - 1);
             const response = [];
 
-            for (let i = offset; i < (offset + limit) && i < users.length; ++i) {
+            for (let i = offset; i < offset + limit && i < users.length; ++i) {
                 response.push(users[i]);
             }
-
 
             if (pagination) {
                 return h.paginate(response, users.length);
@@ -198,10 +193,11 @@ const register = function () {
         method: 'GET',
         path: '/array-exception',
         handler: (request, h) => {
-
-            return h.response({
-                message: 'Custom Error Message'
-            }).code(500);
+            return h
+                .response({
+                    message: 'Custom Error Message'
+                })
+                .code(500);
         }
     });
 
@@ -211,9 +207,11 @@ const register = function () {
         path: '/ws-upgrade',
         handler: (request, h) => {
             // Some WS WORKS for upgrade request
-            return h.response({
-                message: 'WS Upgrade request'
-            }).code(101);
+            return h
+                .response({
+                    message: 'WS Upgrade request'
+                })
+                .code(101);
         }
     });
 
@@ -232,7 +230,6 @@ const register = function () {
             }
         },
         handler: (request, h) => {
-
             return h.paginate([{}, {}, {}], 3);
         }
     });
@@ -249,9 +246,7 @@ const register = function () {
 };
 
 describe('Test with defaults values', () => {
-
     it('Test if limit default is added to request object', async () => {
-
         const server = register();
         await server.register(require(pluginName));
 
@@ -266,9 +261,7 @@ describe('Test with defaults values', () => {
         expect(res.request.response.source.meta.totalCount).to.be.null();
     });
 
-
     it('Test with additional query string', async () => {
-
         const server = register();
         await server.register(require(pluginName));
 
@@ -281,9 +274,7 @@ describe('Test with defaults values', () => {
         expect(res.request.query.paramm).to.equal('2');
     });
 
-
     it('should set the default response status code when data paginated', async () => {
-
         const server = register();
         await server.register(require(pluginName));
 
@@ -297,9 +288,7 @@ describe('Test with defaults values', () => {
 });
 
 describe('Override default values', () => {
-
     it('Override default limit and page', async () => {
-
         const options = {
             query: {
                 limit: {
@@ -334,9 +323,7 @@ describe('Override default values', () => {
         expect(query[page.name]).to.equal(page.default);
     });
 
-
     it('Override defaults routes with include', async () => {
-
         const options = {
             routes: {
                 include: ['/']
@@ -349,7 +336,6 @@ describe('Override default values', () => {
             options
         });
 
-
         const res = await server.inject({
             method: 'GET',
             url: '/'
@@ -361,7 +347,6 @@ describe('Override default values', () => {
     });
 
     it('Override defaults routes with include 2', async () => {
-
         const options = {
             routes: {
                 include: ['/']
@@ -384,9 +369,7 @@ describe('Override default values', () => {
         expect(query.page).to.be.undefined();
     });
 
-
     it('Override defaults routes with regex in include', async () => {
-
         const options = {
             routes: {
                 include: [/^\/u.*s$/]
@@ -399,7 +382,6 @@ describe('Override default values', () => {
             options
         });
 
-
         const res = await server.inject({
             method: 'GET',
             url: '/users'
@@ -411,12 +393,10 @@ describe('Override default values', () => {
     });
 
     it('Override defaults routes with both regex and string in include', async () => {
-
         const options = {
             routes: {
                 include: [/^\/hello$/, '/users']
             }
-
         };
         const server = register();
         await server.register({
@@ -431,12 +411,9 @@ describe('Override default values', () => {
         const query = res.request.query;
         expect(query.limit).to.equal(25);
         expect(query.page).to.equal(1);
-
-
     });
 
     it('Override defaults routes with regex in include without a match', async () => {
-
         const options = {
             routes: {
                 include: [/^\/hello.*$/]
@@ -457,11 +434,9 @@ describe('Override default values', () => {
         const query = res.request.query;
         expect(query.limit).to.be.undefined();
         expect(query.page).to.be.undefined();
-
     });
 
     it('Override defaults routes with exclude', async () => {
-
         const options = {
             routes: {
                 include: ['*'],
@@ -483,11 +458,9 @@ describe('Override default values', () => {
         const query = res.request.query;
         expect(query.limit).to.be.undefined();
         expect(query.page).to.be.undefined();
-
     });
 
     it('Override defaults routes with exclude 2', async () => {
-
         const options = {
             routes: {
                 include: ['/users'],
@@ -509,11 +482,9 @@ describe('Override default values', () => {
         const query = res.request.query;
         expect(query.limit).to.be.undefined();
         expect(query.page).to.be.undefined();
-
     });
 
     it('Override defaults routes with regex in exclude', async () => {
-
         const options = {
             routes: {
                 include: ['*'],
@@ -538,7 +509,6 @@ describe('Override default values', () => {
     });
 
     it('Override defaults routes with both regex and string in exclude', async () => {
-
         const options = {
             routes: {
                 include: ['*'],
@@ -552,7 +522,6 @@ describe('Override default values', () => {
             options
         });
 
-
         const res = await server.inject({
             method: 'GET',
             url: '/'
@@ -561,12 +530,9 @@ describe('Override default values', () => {
         const query = res.request.query;
         expect(query.limit).to.be.undefined();
         expect(query.page).to.be.undefined();
-
-
     });
 
     it('Override results name', async () => {
-
         const server = register();
         await server.register({
             plugin: require(pluginName),
@@ -582,14 +548,11 @@ describe('Override default values', () => {
             method: 'GET'
         });
 
-
         expect(res.request.response.source.rows).to.be.an.array();
         expect(res.request.response.source.rows).to.have.length(12);
-
     });
 
     it('Override reply parametr (results) name', async () => {
-
         const resultsKey = 'rows';
         const server = register();
         await server.register({
@@ -606,18 +569,15 @@ describe('Override default values', () => {
         });
 
         const res = await server.inject({
-            url: '/users3?limit=12&resultsKey=' + resultsKey,
+            url: `/users3?limit=12&resultsKey=${resultsKey}`,
             method: 'GET'
         });
 
         expect(res.request.response.source.results).to.be.an.array();
         expect(res.request.response.source.results).to.have.length(12);
-
-
     });
 
     it('Override reply parametr (totalCount) name', async () => {
-
         const totalCountKey = 'total';
 
         const server = register();
@@ -635,15 +595,17 @@ describe('Override default values', () => {
         });
 
         const res = await server.inject({
-            url: '/users3?limit=12&resultsKey=results&totalCountKey=' + totalCountKey,
+            url:
+                `/users3?limit=12&resultsKey=results&totalCountKey=${totalCountKey}`,
             method: 'GET'
         });
 
-        expect(res.request.response.source.meta.totalCount).to.equal(users.length);
+        expect(res.request.response.source.meta.totalCount).to.equal(
+            users.length
+        );
     });
 
     it('Override defaults routes with regex without a match', async () => {
-
         const options = {
             routes: {
                 include: ['*'],
@@ -657,7 +619,6 @@ describe('Override default values', () => {
             options
         });
 
-
         const res = await server.inject({
             method: 'GET',
             url: '/'
@@ -669,7 +630,6 @@ describe('Override default values', () => {
     });
 
     it('Override names of meta', async () => {
-
         const options = {
             meta: {
                 name: 'myMeta',
@@ -728,7 +688,6 @@ describe('Override default values', () => {
             options
         });
 
-
         const res = await server.inject({
             method: 'GET',
             url: '/'
@@ -749,16 +708,23 @@ describe('Override default values', () => {
         expect(meta[names.hasNext.name]).to.be.false();
         expect(meta[names.hasPrevious.name]).to.be.false();
         expect(meta[names.last.name]).to.be.null();
-        expect(meta[names.first.name]).to.part.include(['http://localhost/?', ' page=1', '&', 'limit=25']);
-        expect(meta[names.self.name]).to.part.include(['http://localhost/?', 'page=1', '&', 'limit=25']);
+        expect(meta[names.first.name]).to.part.include([
+            'http://localhost/?',
+            ' page=1',
+            '&',
+            'limit=25'
+        ]);
+        expect(meta[names.self.name]).to.part.include([
+            'http://localhost/?',
+            'page=1',
+            '&',
+            'limit=25'
+        ]);
         expect(response.results).to.be.an.array();
         expect(response.results).to.have.length(0);
-
-
     });
 
     it('Override query parameter pagination - set active to false', async () => {
-
         const options = {
             query: {
                 limit: {
@@ -785,11 +751,9 @@ describe('Override default values', () => {
         const response = res.request.response.source;
         expect(response.results).to.be.an.array();
         expect(response.results).to.have.length(10);
-
     });
 
     it('Override meta - set active to false', async () => {
-
         const options = {
             meta: {
                 name: 'meta',
@@ -865,7 +829,6 @@ describe('Override default values', () => {
     });
 
     it('Override meta location - move metadata to http headers with multiple pages', async () => {
-
         const options = {
             query: {
                 limit: {
@@ -905,11 +868,9 @@ describe('Override default values', () => {
         expect(headers.Link[4]).match(/rel="prev"$/);
         expect(response).to.be.an.array();
         expect(response).to.have.length(5);
-
     });
 
     it('Override meta location - move metadata to http headers with unique page', async () => {
-
         const options = {
             meta: {
                 location: 'header',
@@ -935,11 +896,9 @@ describe('Override default values', () => {
         expect(headers.Link).to.not.exist;
         expect(response).to.be.an.array();
         expect(response).to.have.length(20);
-
     });
 
     it('Override meta location - move metadata to http headers with first page', async () => {
-
         const options = {
             query: {
                 limit: {
@@ -981,7 +940,6 @@ describe('Override default values', () => {
     });
 
     it('Override meta location - move metadata to http headers with last page', async () => {
-
         const options = {
             query: {
                 limit: {
@@ -1021,11 +979,9 @@ describe('Override default values', () => {
 
         expect(response).to.be.an.array();
         expect(response).to.have.length(5);
-
     });
 
     it('Override meta location - do not set metadata if requested page is out of range', async () => {
-
         const options = {
             query: {
                 limit: {
@@ -1061,11 +1017,9 @@ describe('Override default values', () => {
         const response = res.request.response.source;
         expect(response).to.be.an.array();
         expect(response).to.have.length(0);
-
     });
 
     it('use custom baseUri instead of server provided uri', async () => {
-
         const myCustomUri = 'https://127.0.0.1:81';
         const options = {
             meta: {
@@ -1104,11 +1058,9 @@ describe('Override default values', () => {
         const meta = response.meta;
         expect(meta.first).to.include(myCustomUri);
         expect(meta.self).to.include(myCustomUri);
-
     });
 
     it('Override the response status code with a correct value', async () => {
-
         const options = {
             meta: {
                 successStatusCode: 204
@@ -1121,18 +1073,14 @@ describe('Override default values', () => {
             options
         });
 
-
         const res = await server.inject({
             method: 'GET',
             url: '/users'
         });
         expect(res.statusCode).to.equal(204);
-
-
     });
 
     it('Override the response status code with an unauthorized status code', async () => {
-
         const options = {
             meta: {
                 successStatusCode: 500
@@ -1141,7 +1089,6 @@ describe('Override default values', () => {
 
         const server = register();
         const serverRegister = async () => {
-
             await server.register({
                 plugin: require(pluginName),
                 options
@@ -1149,11 +1096,9 @@ describe('Override default values', () => {
         };
 
         await expect(serverRegister()).to.reject();
-
     });
 
     it('Override the response status code with an incorrect value', async () => {
-
         const options = {
             meta: {
                 successStatusCode: 500
@@ -1163,7 +1108,6 @@ describe('Override default values', () => {
         const server = register();
 
         const serverRegister = async () => {
-
             await server.register({
                 plugin: require(pluginName),
                 options
@@ -1171,11 +1115,9 @@ describe('Override default values', () => {
         };
 
         await expect(serverRegister()).to.reject();
-
     });
 
     it('Do not override the response status code if no pagination', async () => {
-
         const server = register();
         await server.register({
             plugin: require(pluginName)
@@ -1186,14 +1128,11 @@ describe('Override default values', () => {
             url: '/users?pagination=false'
         });
         expect(res.statusCode).to.equal(200);
-
     });
 });
 
 describe('Custom route options', () => {
-
     it('Force a route to include pagination', async () => {
-
         const options = {
             routes: {
                 exclude: ['/enabled']
@@ -1214,11 +1153,9 @@ describe('Custom route options', () => {
         const query = res.request.query;
         expect(query.limit).to.equal(25);
         expect(query.page).to.equal(1);
-
     });
 
     it('Force a route to exclude pagination', async () => {
-
         const options = {
             routes: {
                 include: ['/disabled']
@@ -1239,16 +1176,11 @@ describe('Custom route options', () => {
         const query = res.request.query;
         expect(query.limit).to.be.undefined();
         expect(query.page).to.be.undefined();
-
     });
-
 });
 
-
 describe('Override on route level', () => {
-
     it('Overriden defaults on route level with pagination to false', async () => {
-
         const server = register();
 
         await server.register(require(pluginName));
@@ -1260,11 +1192,9 @@ describe('Override on route level', () => {
 
         expect(res.request.response.source).to.be.an.array();
         expect(res.request.response.source).to.have.length(20);
-
     });
 
     it('Overriden defaults on route level with pagination to true', async () => {
-
         const server = register();
 
         await server.register(require(pluginName));
@@ -1280,15 +1210,12 @@ describe('Override on route level', () => {
         expect(response.meta.totalCount).to.equal(20);
         expect(res.request.query.limit).to.equal(10);
         expect(res.request.query.page).to.equal(2);
-
     });
 
     it('Overriden defaults on route level with limit and page to 5 and 1', async () => {
-
         const server = register();
 
         await server.register(require(pluginName));
-
 
         const res = await server.inject({
             method: 'GET',
@@ -1302,13 +1229,9 @@ describe('Override on route level', () => {
         expect(res.request.query.limit).to.equal(5);
         expect(res.request.query.page).to.equal(1);
     });
-
 });
 
-
-
 describe('Passing page and limit as query parameters', () => {
-
     const options = {
         query: {
             limit: {
@@ -1323,7 +1246,6 @@ describe('Passing page and limit as query parameters', () => {
     };
 
     it('Passing limit', async () => {
-
         const server = register();
 
         server.register(require(pluginName));
@@ -1335,12 +1257,9 @@ describe('Passing page and limit as query parameters', () => {
 
         expect(res.request.query.limit).to.equal(5);
         expect(res.request.query.page).to.equal(1);
-
-
     });
 
     it('Wrong limit and page should return the defaults', async () => {
-
         const server = register();
 
         await server.register(require(pluginName));
@@ -1352,11 +1271,9 @@ describe('Passing page and limit as query parameters', () => {
 
         expect(res.request.query.limit).to.equal(25);
         expect(res.request.query.page).to.equal(1);
-
     });
 
     it('Wrong limit with badRequest behavior should return 400 bad request', async () => {
-
         const server = register();
 
         await server.register({
@@ -1378,7 +1295,6 @@ describe('Passing page and limit as query parameters', () => {
     });
 
     it('Wrong page with badRequest behavior should return 400 bad request', async () => {
-
         const server = register();
 
         await server.register({
@@ -1400,14 +1316,12 @@ describe('Passing page and limit as query parameters', () => {
     });
 
     it('Overriding and passing limit', async () => {
-
         const server = register();
 
         await server.register({
             plugin: require(pluginName),
             options
         });
-
 
         const res = await server.inject({
             method: 'GET',
@@ -1416,15 +1330,12 @@ describe('Passing page and limit as query parameters', () => {
 
         expect(res.request.query[options.query.limit.name]).to.equal(7);
         expect(res.request.query[options.query.page.name]).to.equal(2);
-
     });
 
     it('Passing page', async () => {
-
         const server = register();
 
         await server.register(require(pluginName));
-
 
         const res = await server.inject({
             method: 'GET',
@@ -1432,11 +1343,9 @@ describe('Passing page and limit as query parameters', () => {
         });
 
         expect(res.request.query.page).to.equal(5);
-
     });
 
     it('Overriding and passing page', async () => {
-
         const server = register();
 
         await server.register({
@@ -1451,19 +1360,20 @@ describe('Passing page and limit as query parameters', () => {
 
         expect(res.request.query[options.query.limit.name]).to.equal(5);
         expect(res.request.query[options.query.page.name]).to.equal(5);
-
     });
 });
 
 describe('Test /users route', () => {
-
     it('Test default with totalCount added to request object', async () => {
-
-        const urlForPage = (page) => ['http://localhost/users?', 'page=' + page, '&', 'limit=5'];
+        const urlForPage = (page) => [
+            'http://localhost/users?',
+            `page=${page}`,
+            '&',
+            'limit=5'
+        ];
 
         const server = register();
         await server.register(require(pluginName));
-
 
         const res = await server.inject({
             method: 'GET',
@@ -1484,11 +1394,9 @@ describe('Test /users route', () => {
 
         expect(response.results).to.be.an.array();
         expect(response.results).to.have.length(5);
-
     });
 
     it('Test hasPrev behave correctly', async () => {
-
         const server = register();
         await server.register({
             plugin: require(pluginName),
@@ -1501,7 +1409,6 @@ describe('Test /users route', () => {
             }
         });
 
-
         const res = await server.inject({
             method: 'GET',
             url: '/users?page=1&limit=5'
@@ -1513,9 +1420,7 @@ describe('Test /users route', () => {
 });
 
 describe('Testing pageCount', () => {
-
     it('Limit is 3, page should be 7', async () => {
-
         const server = register();
         await server.register(require(pluginName));
 
@@ -1528,12 +1433,9 @@ describe('Testing pageCount', () => {
         const meta = response.meta;
 
         expect(meta.pageCount).to.equal(7);
-
     });
 
-
     it('Limit is 4, page should be 5', async () => {
-
         const server = register();
         await server.register(require(pluginName));
 
@@ -1548,9 +1450,7 @@ describe('Testing pageCount', () => {
         expect(meta.pageCount).to.equal(5);
     });
 
-
     it('Limit is 1, page should be 20', async () => {
-
         const server = register();
         await server.register(require(pluginName));
 
@@ -1567,9 +1467,7 @@ describe('Testing pageCount', () => {
 });
 
 describe('Post request', () => {
-
     it('Should work with a post request', async () => {
-
         const server = register();
         await server.register(require(pluginName));
 
@@ -1581,14 +1479,11 @@ describe('Post request', () => {
         const response = res.request.response.source;
 
         expect(response).to.equal('Works');
-
     });
 });
 
 describe('Changing pagination query parameter', () => {
-
     it('Should return the results with no pagination', async () => {
-
         const server = register();
         await server.register(require(pluginName));
 
@@ -1599,12 +1494,9 @@ describe('Changing pagination query parameter', () => {
 
         const response = res.request.response.source;
         expect(response).to.be.an.array();
-
     });
 
-
     it('Pagination to random value (default is true)', async () => {
-
         const server = register();
         await server.register(require(pluginName));
 
@@ -1616,11 +1508,9 @@ describe('Changing pagination query parameter', () => {
         const response = res.request.response.source;
         expect(response.meta).to.be.an.object();
         expect(response.results).to.be.an.array();
-
     });
 
     it('Pagination to random value (default is false)', async () => {
-
         const server = register();
         await server.register({
             plugin: require(pluginName),
@@ -1640,11 +1530,9 @@ describe('Changing pagination query parameter', () => {
 
         const response = res.request.response.source;
         expect(response).to.be.an.array();
-
     });
 
     it('Pagination explicitely to true', async () => {
-
         const options = {
             meta: {
                 name: 'myMeta',
@@ -1722,15 +1610,23 @@ describe('Changing pagination query parameter', () => {
         expect(meta[names.hasNext.name]).to.be.false();
         expect(meta[names.hasPrevious.name]).to.be.false();
         expect(meta[names.last.name]).to.be.null();
-        expect(meta[names.first.name]).to.part.include(['http://localhost/?', ' page=1', '&', 'limit=25']);
-        expect(meta[names.self.name]).to.part.include(['http://localhost/?', 'page=1', '&', 'limit=25']);
+        expect(meta[names.first.name]).to.part.include([
+            'http://localhost/?',
+            ' page=1',
+            '&',
+            'limit=25'
+        ]);
+        expect(meta[names.self.name]).to.part.include([
+            'http://localhost/?',
+            'page=1',
+            '&',
+            'limit=25'
+        ]);
         expect(response.results).to.be.an.array();
         expect(response.results).to.have.length(0);
-
     });
 
     it('Pagination default is false', async () => {
-
         const options = {
             query: {
                 pagination: {
@@ -1793,7 +1689,6 @@ describe('Changing pagination query parameter', () => {
             options
         });
 
-
         const res = await server.inject({
             method: 'GET',
             url: '/?pagination=true'
@@ -1818,17 +1713,13 @@ describe('Changing pagination query parameter', () => {
         expect(meta[names.self.name]).to.part.include(['pagination=true']);
         expect(response.results).to.be.an.array();
         expect(response.results).to.have.length(0);
-
     });
 });
 
 describe('Wrong options', () => {
-
     it('Should return an error on register', async () => {
-
         const server = register();
         const serverRegister = async () => {
-
             await server.register({
                 plugin: require(pluginName),
                 options: {
@@ -1845,11 +1736,9 @@ describe('Wrong options', () => {
     });
 
     it('Should return an error on register', async () => {
-
         const server = register();
 
         const serverRegister = async () => {
-
             await server.register({
                 plugin: require(pluginName),
                 options: {
@@ -1861,15 +1750,12 @@ describe('Wrong options', () => {
         };
 
         await expect(serverRegister()).to.reject();
-
     });
 
     it('Should return an error on register', async () => {
-
         const server = register();
 
         const serverRegister = async () => {
-
             await server.register({
                 plugin: require(pluginName),
                 options: {
@@ -1883,15 +1769,12 @@ describe('Wrong options', () => {
         };
 
         await expect(serverRegister()).to.reject();
-
     });
 
     it('Should return an error on register', async () => {
-
         const server = register();
 
         const serverRegister = async () => {
-
             await server.register({
                 plugin: require(pluginName),
                 options: {
@@ -1905,20 +1788,16 @@ describe('Wrong options', () => {
         };
 
         await expect(serverRegister()).to.reject();
-
     });
 
     it('Should return an error on paginate', async () => {
-
         const server = register();
         await server.register(require(pluginName));
         server.route({
             method: 'GET',
             path: '/error',
             handler: (request, h) => {
-               return h.paginate(
-                   [1, 2], 0, { key: 1 }
-                );
+                return h.paginate([1, 2], 0, { key: 1 });
             }
         });
 
@@ -1933,9 +1812,7 @@ describe('Wrong options', () => {
 });
 
 describe('Results with other keys', () => {
-
     it('Should return the response with the original response keys', async () => {
-
         const server = register();
         await server.register(require(pluginName));
 
@@ -1951,21 +1828,17 @@ describe('Results with other keys', () => {
         expect(response.otherKey2).to.equal('otherKey2');
         expect(response.meta).to.exists();
         expect(response.results).to.exists();
-
     });
 
     it('Should return an internal server error', async () => {
-
         const server = register();
 
         await server.register(require(pluginName));
-
 
         server.route({
             method: 'GET',
             path: '/error',
             handler: (request, h) => {
-
                 return h.paginate({ results: [] }, 0);
             }
         });
@@ -1978,22 +1851,17 @@ describe('Results with other keys', () => {
         const res = await server.inject(request);
 
         expect(res.request.response.statusCode).to.equal(500);
-
     });
 
     it('Should return an internal server error #2', async () => {
-
         const server = register();
 
-
         await server.register(require(pluginName));
-
 
         server.route({
             method: 'GET',
             path: '/error',
             handler: (request, h) => {
-
                 return h.paginate({ results: [] }, 0, { key: 'res' });
             }
         });
@@ -2009,7 +1877,6 @@ describe('Results with other keys', () => {
     });
 
     it('Should not override meta and results', async () => {
-
         const server = register();
 
         await server.register(require(pluginName));
@@ -2018,8 +1885,11 @@ describe('Results with other keys', () => {
             method: 'GET',
             path: '/nooverride',
             handler: (request, h) => {
-
-                return h.paginate({ res: [], results: 'results', meta: 'meta' }, 0, { key: 'res' });
+                return h.paginate(
+                    { res: [], results: 'results', meta: 'meta' },
+                    0,
+                    { key: 'res' }
+                );
             }
         });
 
@@ -2033,14 +1903,11 @@ describe('Results with other keys', () => {
         const response = res.request.response.source;
         expect(response.meta).to.not.equal('meta');
         expect(response.results).to.not.equal('results');
-
     });
 });
 
 describe('Empty result set', () => {
-
     it('Counts should be 0', async () => {
-
         const server = register();
         await server.register(require(pluginName));
 
@@ -2055,11 +1922,9 @@ describe('Empty result set', () => {
         expect(response.meta.totalCount).to.equal(0);
         expect(response.meta.pageCount).to.equal(0);
         expect(response.meta.count).to.equal(0);
-
     });
 
     it('Staus code should be >=200 & <=299', async () => {
-
         const server = register();
         await server.register(require(pluginName));
 
@@ -2077,9 +1942,7 @@ describe('Empty result set', () => {
 });
 
 describe('Exception', () => {
-
     it('Should not continue on exception', async () => {
-
         const server = register();
         await server.register(require(pluginName));
         const request = {
@@ -2089,11 +1952,9 @@ describe('Exception', () => {
 
         const res = await server.inject(request);
         expect(res.request.response.statusCode).to.equal(500);
-
     });
 
     it('Should not process further if response code is not in 200 - 299 range', async () => {
-
         const server = register();
         await server.register(require(pluginName));
         const request = {
@@ -2107,11 +1968,9 @@ describe('Exception', () => {
         const message = response.message;
         expect(message).to.equal('Custom Error Message');
         expect(res.request.response.statusCode).to.equal(500);
-
     });
 
     it('Should not process further if upgrade request is received', async () => {
-
         const server = register();
         await server.register(require(pluginName));
 
@@ -2122,14 +1981,11 @@ describe('Exception', () => {
 
         const res = await server.inject(request);
         expect(res.request.response.statusCode).to.equal(101);
-
     });
 });
 
 describe('Override on route level error', () => {
-
     it('Should return an error', async () => {
-
         const server = register();
         server.route({
             path: '/error',
@@ -2143,14 +1999,12 @@ describe('Override on route level error', () => {
                     }
                 },
                 handler: (request, h) => {
-
                     return;
                 }
             }
         });
 
         const serverRegister = async () => {
-
             await server.register(require(pluginName));
         };
 
@@ -2158,7 +2012,6 @@ describe('Override on route level error', () => {
     });
 
     it('Should return an error', async () => {
-
         const server = register();
         server.route({
             path: '/error',
@@ -2176,7 +2029,6 @@ describe('Override on route level error', () => {
         });
 
         const serverRegister = async () => {
-
             await server.register(require(pluginName));
         };
 
@@ -2184,7 +2036,6 @@ describe('Override on route level error', () => {
     });
 
     it('Should return an error', async () => {
-
         const server = register();
         server.route({
             path: '/error',
@@ -2202,7 +2053,6 @@ describe('Override on route level error', () => {
         });
 
         const serverRegister = async () => {
-
             await server.register(require(pluginName));
         };
 
@@ -2210,7 +2060,6 @@ describe('Override on route level error', () => {
     });
 
     it('Should return an error', async () => {
-
         const server = register();
         server.route({
             path: '/error',
@@ -2226,7 +2075,6 @@ describe('Override on route level error', () => {
         });
 
         const serverRegister = async () => {
-
             await server.register(require(pluginName));
         };
 
@@ -2235,16 +2083,19 @@ describe('Override on route level error', () => {
 });
 
 describe('Empty baseUri should give relative url', () => {
-
     it('use custom baseUri instead of server provided uri', async () => {
-
         const options = {
             meta: {
                 baseUri: ''
             }
         };
 
-        const urlForPage = (page) => ['/users?', 'page=' + page, '&', 'limit=5'];
+        const urlForPage = (page) => [
+            '/users?',
+            `page=${page}`,
+            '&',
+            'limit=5'
+        ];
 
         const server = register();
         await server.register({
@@ -2263,30 +2114,24 @@ describe('Empty baseUri should give relative url', () => {
         expect(meta.first).to.not.include('localhost');
         expect(meta.self).to.include(urlForPage(1));
         expect(meta.next).to.include(urlForPage(2));
-
     });
 });
 
-
 describe('Should include original values of query parameters in pagination urls when Joi validation creates objects', () => {
-
     const urlPrefix = 'http://localhost/query-params?';
     const urlPrefixLen = urlPrefix.length;
     const expectedCount = 3;
 
-    const splitParams = function (url) {
-
+    const splitParams = url => {
         expect(url).to.startWith(urlPrefix);
         return url.substr(urlPrefixLen).split('&');
     };
 
     it('Should include dates in pagination urls', async () => {
-
         const dateQuery = 'testDate=1983-01-27';
 
         const server = register();
         await server.register(require(pluginName));
-
 
         const request = {
             method: 'GET',
@@ -2295,7 +2140,9 @@ describe('Should include original values of query parameters in pagination urls 
 
         const res = await server.inject(request);
         expect(res.request.query.testDate).to.be.a.date();
-        expect(res.request.query.testDate.toISOString()).to.equal('1983-01-27T00:00:00.000Z');
+        expect(res.request.query.testDate.toISOString()).to.equal(
+            '1983-01-27T00:00:00.000Z'
+        );
 
         const response = res.request.response.source;
         expect(response.meta.count).to.equal(expectedCount);
@@ -2306,16 +2153,13 @@ describe('Should include original values of query parameters in pagination urls 
         expect(splitParams(response.meta.self)).to.include(dateQuery);
         expect(splitParams(response.meta.first)).to.include(dateQuery);
         expect(splitParams(response.meta.last)).to.include(dateQuery);
-
     });
 
     it('Should include arrays in pagination urls', async () => {
-
         const arrayQuery = `testArray=${encodeURIComponent('[3,4]')}`;
 
         const server = register();
         await server.register(require(pluginName));
-
 
         const request = {
             method: 'GET',
@@ -2323,7 +2167,9 @@ describe('Should include original values of query parameters in pagination urls 
         };
 
         const res = await server.inject(request);
-        expect(res.request.query.testArray).to.be.an.array().and.only.include([3, 4]);
+        expect(res.request.query.testArray)
+            .to.be.an.array()
+            .and.only.include([3, 4]);
 
         const response = res.request.response.source;
         expect(response.meta.count).to.equal(expectedCount);
@@ -2334,12 +2180,12 @@ describe('Should include original values of query parameters in pagination urls 
         expect(splitParams(response.meta.self)).to.include(arrayQuery);
         expect(splitParams(response.meta.first)).to.include(arrayQuery);
         expect(splitParams(response.meta.last)).to.include(arrayQuery);
-
     });
 
     it('Should include objects in pagination urls', async () => {
-
-        const objectQuery = `testObject=${encodeURIComponent(JSON.stringify({ a: 1, b: 2 }))}`;
+        const objectQuery = `testObject=${encodeURIComponent(
+            JSON.stringify({ a: 1, b: 2 })
+        )}`;
 
         const server = register();
         await server.register(require(pluginName));
@@ -2350,7 +2196,9 @@ describe('Should include original values of query parameters in pagination urls 
         };
 
         const res = await server.inject(request);
-        expect(res.request.query.testObject).to.be.an.object().and.only.include({ a: 1, b: 2 });
+        expect(res.request.query.testObject)
+            .to.be.an.object()
+            .and.only.include({ a: 1, b: 2 });
 
         const response = res.request.response.source;
         expect(response.meta.count).to.equal(expectedCount);
@@ -2361,7 +2209,6 @@ describe('Should include original values of query parameters in pagination urls 
         expect(splitParams(response.meta.self)).to.include(objectQuery);
         expect(splitParams(response.meta.first)).to.include(objectQuery);
         expect(splitParams(response.meta.last)).to.include(objectQuery);
-
     });
 });
 
@@ -2381,11 +2228,13 @@ describe('Include custom headers', () => {
         const expectedPageCount = 1;
 
         const res = await server.inject(request);
-        expect(res.request.response.headers[customHeaderName]).to.equal(customHeaderValue);
+        expect(res.request.response.headers[customHeaderName]).to.equal(
+            customHeaderValue
+        );
 
         const response = res.request.response.source;
         expect(response.meta.count).to.equal(expectedCount);
         expect(response.meta.pageCount).to.equal(expectedPageCount);
         expect(response.meta.totalCount).to.equal(expectedCount);
-    });  
+    });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,2332 +1,2321 @@
-'use strict';
+'use strict'
 
-const Code = require('@hapi/code');
-const Lab = require('@hapi/lab');
-const lab = (exports.lab = Lab.script());
-const Hapi = require('@hapi/hapi');
-const Joi = require('@hapi/joi');
+const Code = require('@hapi/code')
+const Lab = require('@hapi/lab')
+const lab = (exports.lab = Lab.script())
+const Hapi = require('@hapi/hapi')
+const Joi = require('@hapi/joi')
 
-const describe = lab.describe;
-const it = lab.it;
-const expect = Code.expect;
+const describe = lab.describe
+const it = lab.it
+const expect = Code.expect
 
-const pluginName = '../lib';
+const pluginName = '../lib'
 
-const users = [];
+const users = []
 for (let i = 0; i < 20; ++i) {
-    users.push({
-        name: `name${i}`,
-        username: `username${i}`
-    });
+  users.push({
+    name: `name${i}`,
+    username: `username${i}`
+  })
 }
 
 const register = () => {
-    const connection = { host: 'localhost' };
-    const server = new Hapi.Server(connection);
+  const connection = { host: 'localhost' }
+  const server = new Hapi.Server(connection)
 
-    server.route({
-        method: 'GET',
-        path: '/',
-        handler: (request, h) => []
-    });
+  server.route({
+    method: 'GET',
+    path: '/',
+    handler: (request, h) => []
+  })
 
-    server.route({
-        method: 'GET',
-        path: '/empty',
-        handler: (request, h) => h.paginate([], 0)
-    });
+  server.route({
+    method: 'GET',
+    path: '/empty',
+    handler: (request, h) => h.paginate([], 0)
+  })
 
-    server.route({
-        method: 'GET',
-        path: '/exception',
-        handler: (request, h) => {
-            throw new Error('test');
-            return h.paginate([], 0);
+  server.route({
+    method: 'GET',
+    path: '/exception',
+    handler: (request, h) => {
+      throw new Error('test')
+      return h.paginate([], 0)
+    }
+  })
+
+  server.route({
+    method: 'GET',
+    path: '/users',
+    handler: (request, h) => {
+      const limit = request.query.limit
+      const page = request.query.page
+      const pagination = request.query.pagination
+
+      const offset = limit * (page - 1)
+      const response = []
+
+      for (let i = offset; i < offset + limit && i < users.length; ++i) {
+        response.push(users[i])
+      }
+
+      if (pagination) {
+        return h.paginate(response, users.length)
+      }
+
+      return h.response(users)
+    }
+  })
+
+  server.route({
+    method: 'GET',
+    path: '/users2',
+    handler: (request, h) => {
+      const limit = request.query.limit
+      const page = request.query.page
+      const pagination = request.query.pagination
+
+      const offset = limit * (page - 1)
+      const response = []
+
+      for (let i = offset; i < offset + limit && i < users.length; ++i) {
+        response.push(users[i])
+      }
+
+      if (pagination) {
+        return h.paginate(
+          {
+            results: response,
+            otherKey: 'otherKey',
+            otherKey2: 'otherKey2'
+          },
+          users.length,
+          { key: 'results' }
+        )
+      }
+
+      return h.response(users)
+    }
+  })
+
+  server.route({
+    method: 'GET',
+    path: '/users3',
+    handler: (request, h) => {
+      const limit = request.query.limit
+      const page = request.query.page
+      const resultsKey = request.query.resultsKey
+      const totalCountKey = request.query.totalCountKey
+
+      const offset = limit * (page - 1)
+
+      const response = {}
+
+      response[resultsKey] = []
+      response[totalCountKey] = users.length
+
+      for (let i = offset; i < offset + limit && i < users.length; ++i) {
+        response[resultsKey].push(users[i])
+      }
+
+      return h.response(response)
+    }
+  })
+
+  server.route({
+    method: 'GET',
+    path: '/enabled',
+    config: {
+      plugins: {
+        pagination: {
+          enabled: true
         }
-    });
+      },
+      handler: (request, h) => []
+    }
+  })
 
-    server.route({
-        method: 'GET',
-        path: '/users',
-        handler: (request, h) => {
-            const limit = request.query.limit;
-            const page = request.query.page;
-            const pagination = request.query.pagination;
-
-            const offset = limit * (page - 1);
-            const response = [];
-
-            for (let i = offset; i < offset + limit && i < users.length; ++i) {
-                response.push(users[i]);
-            }
-
-            if (pagination) {
-                return h.paginate(response, users.length);
-            }
-
-            return h.response(users);
+  server.route({
+    method: 'GET',
+    path: '/disabled',
+    config: {
+      plugins: {
+        pagination: {
+          enabled: false
         }
-    });
+      },
+      handler: (request, h) => []
+    }
+  })
 
-    server.route({
-        method: 'GET',
-        path: '/users2',
-        handler: (request, h) => {
-            const limit = request.query.limit;
-            const page = request.query.page;
-            const pagination = request.query.pagination;
-
-            const offset = limit * (page - 1);
-            const response = [];
-
-            for (let i = offset; i < offset + limit && i < users.length; ++i) {
-                response.push(users[i]);
-            }
-
-            if (pagination) {
-                return h.paginate(
-                    {
-                        results: response,
-                        otherKey: 'otherKey',
-                        otherKey2: 'otherKey2'
-                    },
-                    users.length,
-                    { key: 'results' }
-                );
-            }
-
-            return h.response(users);
+  server.route({
+    method: 'GET',
+    path: '/defaults',
+    config: {
+      plugins: {
+        pagination: {
+          defaults: {
+            pagination: false,
+            limit: 10,
+            page: 2
+          }
         }
-    });
+      }
+    },
+    handler: (request, h) => {
+      const limit = request.query.limit
+      const page = request.query.page
+      const pagination = request.query.pagination
 
-    server.route({
-        method: 'GET',
-        path: '/users3',
-        handler: (request, h) => {
-            const limit = request.query.limit;
-            const page = request.query.page;
-            const resultsKey = request.query.resultsKey;
-            const totalCountKey = request.query.totalCountKey;
+      const offset = limit * (page - 1)
+      const response = []
 
-            const offset = limit * (page - 1);
+      for (let i = offset; i < offset + limit && i < users.length; ++i) {
+        response.push(users[i])
+      }
 
-            const response = {};
+      if (pagination) {
+        return h.paginate(response, users.length)
+      }
 
-            response[resultsKey] = [];
-            response[totalCountKey] = users.length;
+      return h.response(users)
+    }
+  })
 
-            for (let i = offset; i < offset + limit && i < users.length; ++i) {
-                response[resultsKey].push(users[i]);
-            }
+  server.route({
+    method: 'POST',
+    path: '/users',
+    handler: (request, h) => 'Works'
+  })
 
-            return h.response(response);
+  server.route({
+    method: 'GET',
+    path: '/array-exception',
+    handler: (request, h) => {
+      return h
+        .response({
+          message: 'Custom Error Message'
+        })
+        .code(500)
+    }
+  })
+
+  // Dummy Websocket upgrade request
+  server.route({
+    method: 'GET',
+    path: '/ws-upgrade',
+    handler: (request, h) => {
+      // Some WS WORKS for upgrade request
+      return h
+        .response({
+          message: 'WS Upgrade request'
+        })
+        .code(101)
+    }
+  })
+
+  server.route({
+    method: 'GET',
+    path: '/query-params',
+    config: {
+      validate: {
+        query: {
+          testDate: Joi.date(),
+          testArray: Joi.array(),
+          testObject: Joi.object(),
+          page: Joi.number(),
+          limit: Joi.number()
         }
-    });
+      }
+    },
+    handler: (request, h) => {
+      return h.paginate([{}, {}, {}], 3)
+    }
+  })
 
-    server.route({
-        method: 'GET',
-        path: '/enabled',
-        config: {
-            plugins: {
-                pagination: {
-                    enabled: true
-                }
-            },
-            handler: (request, h) => []
-        }
-    });
+  server.route({
+    method: 'GET',
+    path: '/custom-header',
+    handler: (request, h) => {
+      return h.paginate([{}, {}, {}], 3).header('custom-header', 'pizza')
+    }
+  })
 
-    server.route({
-        method: 'GET',
-        path: '/disabled',
-        config: {
-            plugins: {
-                pagination: {
-                    enabled: false
-                }
-            },
-            handler: (request, h) => []
-        }
-    });
-
-    server.route({
-        method: 'GET',
-        path: '/defaults',
-        config: {
-            plugins: {
-                pagination: {
-                    defaults: {
-                        pagination: false,
-                        limit: 10,
-                        page: 2
-                    }
-                }
-            }
-        },
-        handler: (request, h) => {
-            const limit = request.query.limit;
-            const page = request.query.page;
-            const pagination = request.query.pagination;
-
-            const offset = limit * (page - 1);
-            const response = [];
-
-            for (let i = offset; i < offset + limit && i < users.length; ++i) {
-                response.push(users[i]);
-            }
-
-            if (pagination) {
-                return h.paginate(response, users.length);
-            }
-
-            return h.response(users);
-        }
-    });
-
-    server.route({
-        method: 'POST',
-        path: '/users',
-        handler: (request, h) => 'Works'
-    });
-
-    server.route({
-        method: 'GET',
-        path: '/array-exception',
-        handler: (request, h) => {
-            return h
-                .response({
-                    message: 'Custom Error Message'
-                })
-                .code(500);
-        }
-    });
-
-    // Dummy Websocket upgrade request
-    server.route({
-        method: 'GET',
-        path: '/ws-upgrade',
-        handler: (request, h) => {
-            // Some WS WORKS for upgrade request
-            return h
-                .response({
-                    message: 'WS Upgrade request'
-                })
-                .code(101);
-        }
-    });
-
-    server.route({
-        method: 'GET',
-        path: '/query-params',
-        config: {
-            validate: {
-                query: {
-                    testDate: Joi.date(),
-                    testArray: Joi.array(),
-                    testObject: Joi.object(),
-                    page: Joi.number(),
-                    limit: Joi.number()
-                }
-            }
-        },
-        handler: (request, h) => {
-            return h.paginate([{}, {}, {}], 3);
-        }
-    });
-
-    server.route({
-        method: 'GET',
-        path: '/custom-header',
-        handler: (request, h) => {
-            return h.paginate([{}, {}, {}], 3).header('custom-header', 'pizza');
-        }
-    });
-
-    return server;
-};
+  return server
+}
 
 describe('Test with defaults values', () => {
-    it('Test if limit default is added to request object', async () => {
-        const server = register();
-        await server.register(require(pluginName));
+  it('Test if limit default is added to request object', async () => {
+    const server = register()
+    await server.register(require(pluginName))
 
-        const request = {
-            method: 'GET',
-            url: '/'
-        };
+    const request = {
+      method: 'GET',
+      url: '/'
+    }
 
-        const res = await server.inject(request);
-        expect(res.request.query.limit).to.equal(25);
-        expect(res.request.query.page).to.equal(1);
-        expect(res.request.response.source.meta.totalCount).to.be.null();
-    });
+    const res = await server.inject(request)
+    expect(res.request.query.limit).to.equal(25)
+    expect(res.request.query.page).to.equal(1)
+    expect(res.request.response.source.meta.totalCount).to.be.null()
+  })
 
-    it('Test with additional query string', async () => {
-        const server = register();
-        await server.register(require(pluginName));
+  it('Test with additional query string', async () => {
+    const server = register()
+    await server.register(require(pluginName))
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/?param=1&paramm=2'
-        });
+    const res = await server.inject({
+      method: 'GET',
+      url: '/?param=1&paramm=2'
+    })
 
-        expect(res.request.query.param).to.equal('1');
-        expect(res.request.query.paramm).to.equal('2');
-    });
+    expect(res.request.query.param).to.equal('1')
+    expect(res.request.query.paramm).to.equal('2')
+  })
 
-    it('should set the default response status code when data paginated', async () => {
-        const server = register();
-        await server.register(require(pluginName));
+  it('should set the default response status code when data paginated', async () => {
+    const server = register()
+    await server.register(require(pluginName))
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/users'
-        });
+    const res = await server.inject({
+      method: 'GET',
+      url: '/users'
+    })
 
-        expect(res.statusCode).to.equal(200);
-    });
-});
+    expect(res.statusCode).to.equal(200)
+  })
+})
 
 describe('Override default values', () => {
-    it('Override default limit and page', async () => {
-        const options = {
-            query: {
-                limit: {
-                    default: 7,
-                    name: 'myLimit'
-                },
-                page: {
-                    default: 2,
-                    name: 'myPage'
-                }
+  it('Override default limit and page', async () => {
+    const options = {
+      query: {
+        limit: {
+          default: 7,
+          name: 'myLimit'
+        },
+        page: {
+          default: 2,
+          name: 'myPage'
+        }
+      }
+    }
+
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/'
+    })
+
+    const query = res.request.query
+    expect(query.limit).to.be.undefined()
+    expect(query.page).to.be.undefined()
+
+    const limit = options.query.limit
+    const page = options.query.page
+    expect(query[limit.name]).to.equal(limit.default)
+    expect(query[page.name]).to.equal(page.default)
+  })
+
+  it('Override defaults routes with include', async () => {
+    const options = {
+      routes: {
+        include: ['/']
+      }
+    }
+
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/'
+    })
+
+    const query = res.request.query
+    expect(query.limit).to.equal(25)
+    expect(query.page).to.equal(1)
+  })
+
+  it('Override defaults routes with include 2', async () => {
+    const options = {
+      routes: {
+        include: ['/']
+      }
+    }
+
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/users'
+    })
+
+    const query = res.request.query
+    expect(query.limit).to.be.undefined()
+    expect(query.page).to.be.undefined()
+  })
+
+  it('Override defaults routes with regex in include', async () => {
+    const options = {
+      routes: {
+        include: [/^\/u.*s$/]
+      }
+    }
+
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/users'
+    })
+
+    const query = res.request.query
+    expect(query.limit).to.equal(25)
+    expect(query.page).to.equal(1)
+  })
+
+  it('Override defaults routes with both regex and string in include', async () => {
+    const options = {
+      routes: {
+        include: [/^\/hello$/, '/users']
+      }
+    }
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/users'
+    })
+    const query = res.request.query
+    expect(query.limit).to.equal(25)
+    expect(query.page).to.equal(1)
+  })
+
+  it('Override defaults routes with regex in include without a match', async () => {
+    const options = {
+      routes: {
+        include: [/^\/hello.*$/]
+      }
+    }
+
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/users'
+    })
+
+    const query = res.request.query
+    expect(query.limit).to.be.undefined()
+    expect(query.page).to.be.undefined()
+  })
+
+  it('Override defaults routes with exclude', async () => {
+    const options = {
+      routes: {
+        include: ['*'],
+        exclude: ['/']
+      }
+    }
+
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/'
+    })
+
+    const query = res.request.query
+    expect(query.limit).to.be.undefined()
+    expect(query.page).to.be.undefined()
+  })
+
+  it('Override defaults routes with exclude 2', async () => {
+    const options = {
+      routes: {
+        include: ['/users'],
+        exclude: ['/']
+      }
+    }
+
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/'
+    })
+
+    const query = res.request.query
+    expect(query.limit).to.be.undefined()
+    expect(query.page).to.be.undefined()
+  })
+
+  it('Override defaults routes with regex in exclude', async () => {
+    const options = {
+      routes: {
+        include: ['*'],
+        exclude: [/^\/.*/]
+      }
+    }
+
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/'
+    })
+
+    const query = res.request.query
+    expect(query.limit).to.be.undefined()
+    expect(query.page).to.be.undefined()
+  })
+
+  it('Override defaults routes with both regex and string in exclude', async () => {
+    const options = {
+      routes: {
+        include: ['*'],
+        exclude: [/^nothing/, '/']
+      }
+    }
+
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/'
+    })
+
+    const query = res.request.query
+    expect(query.limit).to.be.undefined()
+    expect(query.page).to.be.undefined()
+  })
+
+  it('Override results name', async () => {
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options: {
+        results: {
+          name: 'rows'
+        }
+      }
+    })
+
+    const res = await server.inject({
+      url: '/users?limit=12',
+      method: 'GET'
+    })
+
+    expect(res.request.response.source.rows).to.be.an.array()
+    expect(res.request.response.source.rows).to.have.length(12)
+  })
+
+  it('Override reply parametr (results) name', async () => {
+    const resultsKey = 'rows'
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options: {
+        reply: {
+          parameters: {
+            results: {
+              name: 'rows'
             }
-        };
+          }
+        }
+      }
+    })
 
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
+    const res = await server.inject({
+      url: `/users3?limit=12&resultsKey=${resultsKey}`,
+      method: 'GET'
+    })
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/'
-        });
+    expect(res.request.response.source.results).to.be.an.array()
+    expect(res.request.response.source.results).to.have.length(12)
+  })
 
-        const query = res.request.query;
-        expect(query.limit).to.be.undefined();
-        expect(query.page).to.be.undefined();
+  it('Override reply parametr (totalCount) name', async () => {
+    const totalCountKey = 'total'
 
-        const limit = options.query.limit;
-        const page = options.query.page;
-        expect(query[limit.name]).to.equal(limit.default);
-        expect(query[page.name]).to.equal(page.default);
-    });
-
-    it('Override defaults routes with include', async () => {
-        const options = {
-            routes: {
-                include: ['/']
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options: {
+        reply: {
+          parameters: {
+            totalCount: {
+              name: 'total'
             }
-        };
-
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/'
-        });
-
-        const query = res.request.query;
-        expect(query.limit).to.equal(25);
-        expect(query.page).to.equal(1);
-    });
-
-    it('Override defaults routes with include 2', async () => {
-        const options = {
-            routes: {
-                include: ['/']
-            }
-        };
-
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/users'
-        });
-
-        const query = res.request.query;
-        expect(query.limit).to.be.undefined();
-        expect(query.page).to.be.undefined();
-    });
-
-    it('Override defaults routes with regex in include', async () => {
-        const options = {
-            routes: {
-                include: [/^\/u.*s$/]
-            }
-        };
-
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/users'
-        });
-
-        const query = res.request.query;
-        expect(query.limit).to.equal(25);
-        expect(query.page).to.equal(1);
-    });
-
-    it('Override defaults routes with both regex and string in include', async () => {
-        const options = {
-            routes: {
-                include: [/^\/hello$/, '/users']
-            }
-        };
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/users'
-        });
-        const query = res.request.query;
-        expect(query.limit).to.equal(25);
-        expect(query.page).to.equal(1);
-    });
-
-    it('Override defaults routes with regex in include without a match', async () => {
-        const options = {
-            routes: {
-                include: [/^\/hello.*$/]
-            }
-        };
-
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/users'
-        });
-
-        const query = res.request.query;
-        expect(query.limit).to.be.undefined();
-        expect(query.page).to.be.undefined();
-    });
-
-    it('Override defaults routes with exclude', async () => {
-        const options = {
-            routes: {
-                include: ['*'],
-                exclude: ['/']
-            }
-        };
-
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/'
-        });
-
-        const query = res.request.query;
-        expect(query.limit).to.be.undefined();
-        expect(query.page).to.be.undefined();
-    });
-
-    it('Override defaults routes with exclude 2', async () => {
-        const options = {
-            routes: {
-                include: ['/users'],
-                exclude: ['/']
-            }
-        };
-
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/'
-        });
-
-        const query = res.request.query;
-        expect(query.limit).to.be.undefined();
-        expect(query.page).to.be.undefined();
-    });
-
-    it('Override defaults routes with regex in exclude', async () => {
-        const options = {
-            routes: {
-                include: ['*'],
-                exclude: [/^\/.*/]
-            }
-        };
-
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/'
-        });
-
-        const query = res.request.query;
-        expect(query.limit).to.be.undefined();
-        expect(query.page).to.be.undefined();
-    });
-
-    it('Override defaults routes with both regex and string in exclude', async () => {
-        const options = {
-            routes: {
-                include: ['*'],
-                exclude: [/^nothing/, '/']
-            }
-        };
-
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/'
-        });
-
-        const query = res.request.query;
-        expect(query.limit).to.be.undefined();
-        expect(query.page).to.be.undefined();
-    });
-
-    it('Override results name', async () => {
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options: {
-                results: {
-                    name: 'rows'
-                }
-            }
-        });
-
-        const res = await server.inject({
-            url: '/users?limit=12',
-            method: 'GET'
-        });
-
-        expect(res.request.response.source.rows).to.be.an.array();
-        expect(res.request.response.source.rows).to.have.length(12);
-    });
-
-    it('Override reply parametr (results) name', async () => {
-        const resultsKey = 'rows';
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options: {
-                reply: {
-                    parameters: {
-                        results: {
-                            name: 'rows'
-                        }
-                    }
-                }
-            }
-        });
-
-        const res = await server.inject({
-            url: `/users3?limit=12&resultsKey=${resultsKey}`,
-            method: 'GET'
-        });
-
-        expect(res.request.response.source.results).to.be.an.array();
-        expect(res.request.response.source.results).to.have.length(12);
-    });
-
-    it('Override reply parametr (totalCount) name', async () => {
-        const totalCountKey = 'total';
-
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options: {
-                reply: {
-                    parameters: {
-                        totalCount: {
-                            name: 'total'
-                        }
-                    }
-                }
-            }
-        });
-
-        const res = await server.inject({
-            url: `/users3?limit=12&resultsKey=results&totalCountKey=${totalCountKey}`,
-            method: 'GET'
-        });
-
-        expect(res.request.response.source.meta.totalCount).to.equal(
-            users.length
-        );
-    });
-
-    it('Override defaults routes with regex without a match', async () => {
-        const options = {
-            routes: {
-                include: ['*'],
-                exclude: [/^nothing/]
-            }
-        };
-
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/'
-        });
-
-        const query = res.request.query;
-        expect(query.limit).to.equal(25);
-        expect(query.page).to.equal(1);
-    });
-
-    it('Override names of meta', async () => {
-        const options = {
-            meta: {
-                name: 'myMeta',
-                count: {
-                    active: true,
-                    name: 'myCount'
-                },
-                totalCount: {
-                    active: true,
-                    name: 'myTotalCount'
-                },
-                pageCount: {
-                    active: true,
-                    name: 'myPageCount'
-                },
-                self: {
-                    active: true,
-                    name: 'mySelf'
-                },
-                previous: {
-                    active: true,
-                    name: 'myPrevious'
-                },
-                next: {
-                    active: true,
-                    name: 'myNext'
-                },
-                hasNext: {
-                    active: true,
-                    name: 'myHasNext'
-                },
-                hasPrevious: {
-                    active: true,
-                    name: 'myHasPrev'
-                },
-                first: {
-                    active: true,
-                    name: 'myFirst'
-                },
-                last: {
-                    active: true,
-                    name: 'myLast'
-                },
-                limit: {
-                    active: true
-                },
-                page: {
-                    active: true
-                }
-            }
-        };
-
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/'
-        });
-
-        const response = res.request.response.source;
-        const names = options.meta;
-
-        const meta = response[names.name];
-        expect(meta).to.be.an.object();
-        expect(meta.limit).to.equal(25);
-        expect(meta.page).to.equal(1);
-        expect(meta[names.count.name]).to.equal(0);
-        expect(meta[names.totalCount.name]).to.be.null();
-        expect(meta[names.pageCount.name]).to.be.null();
-        expect(meta[names.previous.name]).to.be.null();
-        expect(meta[names.next.name]).to.be.null();
-        expect(meta[names.hasNext.name]).to.be.false();
-        expect(meta[names.hasPrevious.name]).to.be.false();
-        expect(meta[names.last.name]).to.be.null();
-        expect(meta[names.first.name]).to.part.include([
-            'http://localhost/?',
-            ' page=1',
-            '&',
-            'limit=25'
-        ]);
-        expect(meta[names.self.name]).to.part.include([
-            'http://localhost/?',
-            'page=1',
-            '&',
-            'limit=25'
-        ]);
-        expect(response.results).to.be.an.array();
-        expect(response.results).to.have.length(0);
-    });
-
-    it('Override query parameter pagination - set active to false', async () => {
-        const options = {
-            query: {
-                limit: {
-                    default: 10
-                },
-                pagination: {
-                    default: true,
-                    active: false
-                }
-            }
-        };
-
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/users?pagination=false'
-        });
-
-        const response = res.request.response.source;
-        expect(response.results).to.be.an.array();
-        expect(response.results).to.have.length(10);
-    });
-
-    it('Override meta - set active to false', async () => {
-        const options = {
-            meta: {
-                name: 'meta',
-                count: {
-                    active: false
-                },
-                totalCount: {
-                    active: false
-                },
-                pageCount: {
-                    active: false
-                },
-                self: {
-                    active: false
-                },
-                previous: {
-                    active: false
-                },
-                next: {
-                    active: false
-                },
-                hasNext: {
-                    active: false
-                },
-                hasPrevious: {
-                    active: false
-                },
-                first: {
-                    active: false
-                },
-                last: {
-                    active: false
-                },
-                limit: {
-                    active: false
-                },
-                page: {
-                    active: false
-                }
-            }
-        };
-
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/'
-        });
-
-        const response = res.request.response.source;
-        const names = options.meta;
-
-        const meta = response[names.name];
-        expect(meta).to.be.an.object();
-        expect(meta.limit).to.be.undefined();
-        expect(meta.page).to.be.undefined();
-        expect(meta.count).to.be.undefined();
-        expect(meta.totalCount).to.be.undefined();
-        expect(meta.pageCount).to.be.undefined();
-        expect(meta.previous).to.be.undefined();
-        expect(meta.next).to.be.undefined();
-        expect(meta.hasNext).to.be.undefined();
-        expect(meta.hasPrevious).to.be.undefined();
-        expect(meta.last).to.be.undefined();
-        expect(meta.first).to.be.undefined();
-        expect(meta.self).to.be.undefined();
-        expect(response.results).to.be.an.array();
-        expect(response.results).to.have.length(0);
-    });
-
-    it('Override meta location - move metadata to http headers with multiple pages', async () => {
-        const options = {
-            query: {
-                limit: {
-                    default: 5
-                },
-                page: {
-                    default: 2
-                }
-            },
-            meta: {
-                location: 'header',
-                successStatusCode: 206
-            }
-        };
-
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/users'
-        });
-        const statusCode = res.request.response.statusCode;
-        expect(statusCode).to.equal(206);
-        const headers = res.request.response.headers;
-        const response = res.request.response.source;
-        expect(headers['Content-Range']).to.equal('5-9/20');
-        expect(headers.Link).to.be.an.array();
-        expect(headers.Link).to.have.length(5);
-        expect(headers.Link[0]).match(/rel="self"$/);
-        expect(headers.Link[1]).match(/rel="first"$/);
-        expect(headers.Link[2]).match(/rel="last"$/);
-        expect(headers.Link[3]).match(/rel="next"$/);
-        expect(headers.Link[4]).match(/rel="prev"$/);
-        expect(response).to.be.an.array();
-        expect(response).to.have.length(5);
-    });
-
-    it('Override meta location - move metadata to http headers with unique page', async () => {
-        const options = {
-            meta: {
-                location: 'header',
-                successStatusCode: 206
-            }
-        };
-
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/users'
-        });
-        const statusCode = res.request.response.statusCode;
-        expect(statusCode).to.equal(200);
-        const headers = res.request.response.headers;
-        const response = res.request.response.source;
-        expect(headers['Content-Range']).to.not.exist;
-        expect(headers.Link).to.not.exist;
-        expect(response).to.be.an.array();
-        expect(response).to.have.length(20);
-    });
-
-    it('Override meta location - move metadata to http headers with first page', async () => {
-        const options = {
-            query: {
-                limit: {
-                    default: 5
-                },
-                page: {
-                    default: 1
-                }
-            },
-            meta: {
-                location: 'header'
-            }
-        };
-
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/users'
-        });
-        const statusCode = res.request.response.statusCode;
-        expect(statusCode).to.equal(200);
-        const headers = res.request.response.headers;
-        const response = res.request.response.source;
-        expect(headers['Content-Range']).to.equal('0-4/20');
-        expect(headers.Link).to.be.an.array();
-        expect(headers.Link).to.have.length(4);
-        expect(headers.Link[0]).match(/rel="self"$/);
-        expect(headers.Link[1]).match(/rel="first"$/);
-        expect(headers.Link[2]).match(/rel="last"$/);
-        expect(headers.Link[3]).match(/rel="next"$/);
-
-        expect(response).to.be.an.array();
-        expect(response).to.have.length(5);
-    });
-
-    it('Override meta location - move metadata to http headers with last page', async () => {
-        const options = {
-            query: {
-                limit: {
-                    default: 5
-                },
-                page: {
-                    default: 4
-                }
-            },
-            meta: {
-                location: 'header'
-            }
-        };
-
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/users'
-        });
-
-        const statusCode = res.request.response.statusCode;
-        expect(statusCode).to.equal(200);
-        const headers = res.request.response.headers;
-        const response = res.request.response.source;
-        expect(headers['Content-Range']).to.equal('15-19/20');
-        expect(headers.Link).to.be.an.array();
-        expect(headers.Link).to.have.length(4);
-        expect(headers.Link[0]).match(/rel="self"$/);
-        expect(headers.Link[1]).match(/rel="first"$/);
-        expect(headers.Link[2]).match(/rel="last"$/);
-        expect(headers.Link[3]).match(/rel="prev"$/);
-
-        expect(response).to.be.an.array();
-        expect(response).to.have.length(5);
-    });
-
-    it('Override meta location - do not set metadata if requested page is out of range', async () => {
-        const options = {
-            query: {
-                limit: {
-                    default: 5
-                },
-                page: {
-                    default: 5
-                }
-            },
-            meta: {
-                location: 'header',
-                successStatusCode: 206
-            }
-        };
-
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/users'
-        });
-        const statusCode = res.request.response.statusCode;
-        expect(statusCode).to.equal(200);
-
-        const headers = res.request.response.headers;
-        expect(headers['Content-Range']).to.not.exist;
-        expect(headers.Link).to.not.exist;
-
-        const response = res.request.response.source;
-        expect(response).to.be.an.array();
-        expect(response).to.have.length(0);
-    });
-
-    it('use custom baseUri instead of server provided uri', async () => {
-        const myCustomUri = 'https://127.0.0.1:81';
-        const options = {
-            meta: {
-                baseUri: myCustomUri,
-                name: 'meta',
-                count: {
-                    active: true
-                },
-                totalCount: {
-                    active: true
-                },
-                pageCount: {
-                    active: true
-                },
-                self: {
-                    active: true
-                },
-                first: {
-                    active: true
-                }
-            }
-        };
-
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/'
-        });
-
-        const response = res.request.response.source;
-        const meta = response.meta;
-        expect(meta.first).to.include(myCustomUri);
-        expect(meta.self).to.include(myCustomUri);
-    });
-
-    it('Override the response status code with a correct value', async () => {
-        const options = {
-            meta: {
-                successStatusCode: 204
-            }
-        };
-
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/users'
-        });
-        expect(res.statusCode).to.equal(204);
-    });
-
-    it('Override the response status code with an unauthorized status code', async () => {
-        const options = {
-            meta: {
-                successStatusCode: 500
-            }
-        };
-
-        const server = register();
-        const serverRegister = async () => {
-            await server.register({
-                plugin: require(pluginName),
-                options
-            });
-        };
-
-        await expect(serverRegister()).to.reject();
-    });
-
-    it('Override the response status code with an incorrect value', async () => {
-        const options = {
-            meta: {
-                successStatusCode: 500
-            }
-        };
-
-        const server = register();
-
-        const serverRegister = async () => {
-            await server.register({
-                plugin: require(pluginName),
-                options
-            });
-        };
-
-        await expect(serverRegister()).to.reject();
-    });
-
-    it('Do not override the response status code if no pagination', async () => {
-        const server = register();
-        await server.register({
-            plugin: require(pluginName)
-        });
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/users?pagination=false'
-        });
-        expect(res.statusCode).to.equal(200);
-    });
-});
+          }
+        }
+      }
+    })
+
+    const res = await server.inject({
+      url: `/users3?limit=12&resultsKey=results&totalCountKey=${totalCountKey}`,
+      method: 'GET'
+    })
+
+    expect(res.request.response.source.meta.totalCount).to.equal(users.length)
+  })
+
+  it('Override defaults routes with regex without a match', async () => {
+    const options = {
+      routes: {
+        include: ['*'],
+        exclude: [/^nothing/]
+      }
+    }
+
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/'
+    })
+
+    const query = res.request.query
+    expect(query.limit).to.equal(25)
+    expect(query.page).to.equal(1)
+  })
+
+  it('Override names of meta', async () => {
+    const options = {
+      meta: {
+        name: 'myMeta',
+        count: {
+          active: true,
+          name: 'myCount'
+        },
+        totalCount: {
+          active: true,
+          name: 'myTotalCount'
+        },
+        pageCount: {
+          active: true,
+          name: 'myPageCount'
+        },
+        self: {
+          active: true,
+          name: 'mySelf'
+        },
+        previous: {
+          active: true,
+          name: 'myPrevious'
+        },
+        next: {
+          active: true,
+          name: 'myNext'
+        },
+        hasNext: {
+          active: true,
+          name: 'myHasNext'
+        },
+        hasPrevious: {
+          active: true,
+          name: 'myHasPrev'
+        },
+        first: {
+          active: true,
+          name: 'myFirst'
+        },
+        last: {
+          active: true,
+          name: 'myLast'
+        },
+        limit: {
+          active: true
+        },
+        page: {
+          active: true
+        }
+      }
+    }
+
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/'
+    })
+
+    const response = res.request.response.source
+    const names = options.meta
+
+    const meta = response[names.name]
+    expect(meta).to.be.an.object()
+    expect(meta.limit).to.equal(25)
+    expect(meta.page).to.equal(1)
+    expect(meta[names.count.name]).to.equal(0)
+    expect(meta[names.totalCount.name]).to.be.null()
+    expect(meta[names.pageCount.name]).to.be.null()
+    expect(meta[names.previous.name]).to.be.null()
+    expect(meta[names.next.name]).to.be.null()
+    expect(meta[names.hasNext.name]).to.be.false()
+    expect(meta[names.hasPrevious.name]).to.be.false()
+    expect(meta[names.last.name]).to.be.null()
+    expect(meta[names.first.name]).to.part.include([
+      'http://localhost/?',
+      ' page=1',
+      '&',
+      'limit=25'
+    ])
+    expect(meta[names.self.name]).to.part.include([
+      'http://localhost/?',
+      'page=1',
+      '&',
+      'limit=25'
+    ])
+    expect(response.results).to.be.an.array()
+    expect(response.results).to.have.length(0)
+  })
+
+  it('Override query parameter pagination - set active to false', async () => {
+    const options = {
+      query: {
+        limit: {
+          default: 10
+        },
+        pagination: {
+          default: true,
+          active: false
+        }
+      }
+    }
+
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/users?pagination=false'
+    })
+
+    const response = res.request.response.source
+    expect(response.results).to.be.an.array()
+    expect(response.results).to.have.length(10)
+  })
+
+  it('Override meta - set active to false', async () => {
+    const options = {
+      meta: {
+        name: 'meta',
+        count: {
+          active: false
+        },
+        totalCount: {
+          active: false
+        },
+        pageCount: {
+          active: false
+        },
+        self: {
+          active: false
+        },
+        previous: {
+          active: false
+        },
+        next: {
+          active: false
+        },
+        hasNext: {
+          active: false
+        },
+        hasPrevious: {
+          active: false
+        },
+        first: {
+          active: false
+        },
+        last: {
+          active: false
+        },
+        limit: {
+          active: false
+        },
+        page: {
+          active: false
+        }
+      }
+    }
+
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/'
+    })
+
+    const response = res.request.response.source
+    const names = options.meta
+
+    const meta = response[names.name]
+    expect(meta).to.be.an.object()
+    expect(meta.limit).to.be.undefined()
+    expect(meta.page).to.be.undefined()
+    expect(meta.count).to.be.undefined()
+    expect(meta.totalCount).to.be.undefined()
+    expect(meta.pageCount).to.be.undefined()
+    expect(meta.previous).to.be.undefined()
+    expect(meta.next).to.be.undefined()
+    expect(meta.hasNext).to.be.undefined()
+    expect(meta.hasPrevious).to.be.undefined()
+    expect(meta.last).to.be.undefined()
+    expect(meta.first).to.be.undefined()
+    expect(meta.self).to.be.undefined()
+    expect(response.results).to.be.an.array()
+    expect(response.results).to.have.length(0)
+  })
+
+  it('Override meta location - move metadata to http headers with multiple pages', async () => {
+    const options = {
+      query: {
+        limit: {
+          default: 5
+        },
+        page: {
+          default: 2
+        }
+      },
+      meta: {
+        location: 'header',
+        successStatusCode: 206
+      }
+    }
+
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/users'
+    })
+    const statusCode = res.request.response.statusCode
+    expect(statusCode).to.equal(206)
+    const headers = res.request.response.headers
+    const response = res.request.response.source
+    expect(headers['Content-Range']).to.equal('5-9/20')
+    expect(headers.Link).to.be.an.array()
+    expect(headers.Link).to.have.length(5)
+    expect(headers.Link[0]).match(/rel="self"$/)
+    expect(headers.Link[1]).match(/rel="first"$/)
+    expect(headers.Link[2]).match(/rel="last"$/)
+    expect(headers.Link[3]).match(/rel="next"$/)
+    expect(headers.Link[4]).match(/rel="prev"$/)
+    expect(response).to.be.an.array()
+    expect(response).to.have.length(5)
+  })
+
+  it('Override meta location - move metadata to http headers with unique page', async () => {
+    const options = {
+      meta: {
+        location: 'header',
+        successStatusCode: 206
+      }
+    }
+
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/users'
+    })
+    const statusCode = res.request.response.statusCode
+    expect(statusCode).to.equal(200)
+    const headers = res.request.response.headers
+    const response = res.request.response.source
+    expect(headers['Content-Range']).to.not.exist
+    expect(headers.Link).to.not.exist
+    expect(response).to.be.an.array()
+    expect(response).to.have.length(20)
+  })
+
+  it('Override meta location - move metadata to http headers with first page', async () => {
+    const options = {
+      query: {
+        limit: {
+          default: 5
+        },
+        page: {
+          default: 1
+        }
+      },
+      meta: {
+        location: 'header'
+      }
+    }
+
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/users'
+    })
+    const statusCode = res.request.response.statusCode
+    expect(statusCode).to.equal(200)
+    const headers = res.request.response.headers
+    const response = res.request.response.source
+    expect(headers['Content-Range']).to.equal('0-4/20')
+    expect(headers.Link).to.be.an.array()
+    expect(headers.Link).to.have.length(4)
+    expect(headers.Link[0]).match(/rel="self"$/)
+    expect(headers.Link[1]).match(/rel="first"$/)
+    expect(headers.Link[2]).match(/rel="last"$/)
+    expect(headers.Link[3]).match(/rel="next"$/)
+
+    expect(response).to.be.an.array()
+    expect(response).to.have.length(5)
+  })
+
+  it('Override meta location - move metadata to http headers with last page', async () => {
+    const options = {
+      query: {
+        limit: {
+          default: 5
+        },
+        page: {
+          default: 4
+        }
+      },
+      meta: {
+        location: 'header'
+      }
+    }
+
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/users'
+    })
+
+    const statusCode = res.request.response.statusCode
+    expect(statusCode).to.equal(200)
+    const headers = res.request.response.headers
+    const response = res.request.response.source
+    expect(headers['Content-Range']).to.equal('15-19/20')
+    expect(headers.Link).to.be.an.array()
+    expect(headers.Link).to.have.length(4)
+    expect(headers.Link[0]).match(/rel="self"$/)
+    expect(headers.Link[1]).match(/rel="first"$/)
+    expect(headers.Link[2]).match(/rel="last"$/)
+    expect(headers.Link[3]).match(/rel="prev"$/)
+
+    expect(response).to.be.an.array()
+    expect(response).to.have.length(5)
+  })
+
+  it('Override meta location - do not set metadata if requested page is out of range', async () => {
+    const options = {
+      query: {
+        limit: {
+          default: 5
+        },
+        page: {
+          default: 5
+        }
+      },
+      meta: {
+        location: 'header',
+        successStatusCode: 206
+      }
+    }
+
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/users'
+    })
+    const statusCode = res.request.response.statusCode
+    expect(statusCode).to.equal(200)
+
+    const headers = res.request.response.headers
+    expect(headers['Content-Range']).to.not.exist
+    expect(headers.Link).to.not.exist
+
+    const response = res.request.response.source
+    expect(response).to.be.an.array()
+    expect(response).to.have.length(0)
+  })
+
+  it('use custom baseUri instead of server provided uri', async () => {
+    const myCustomUri = 'https://127.0.0.1:81'
+    const options = {
+      meta: {
+        baseUri: myCustomUri,
+        name: 'meta',
+        count: {
+          active: true
+        },
+        totalCount: {
+          active: true
+        },
+        pageCount: {
+          active: true
+        },
+        self: {
+          active: true
+        },
+        first: {
+          active: true
+        }
+      }
+    }
+
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/'
+    })
+
+    const response = res.request.response.source
+    const meta = response.meta
+    expect(meta.first).to.include(myCustomUri)
+    expect(meta.self).to.include(myCustomUri)
+  })
+
+  it('Override the response status code with a correct value', async () => {
+    const options = {
+      meta: {
+        successStatusCode: 204
+      }
+    }
+
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/users'
+    })
+    expect(res.statusCode).to.equal(204)
+  })
+
+  it('Override the response status code with an unauthorized status code', async () => {
+    const options = {
+      meta: {
+        successStatusCode: 500
+      }
+    }
+
+    const server = register()
+    const serverRegister = async () => {
+      await server.register({
+        plugin: require(pluginName),
+        options
+      })
+    }
+
+    await expect(serverRegister()).to.reject()
+  })
+
+  it('Override the response status code with an incorrect value', async () => {
+    const options = {
+      meta: {
+        successStatusCode: 500
+      }
+    }
+
+    const server = register()
+
+    const serverRegister = async () => {
+      await server.register({
+        plugin: require(pluginName),
+        options
+      })
+    }
+
+    await expect(serverRegister()).to.reject()
+  })
+
+  it('Do not override the response status code if no pagination', async () => {
+    const server = register()
+    await server.register({
+      plugin: require(pluginName)
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/users?pagination=false'
+    })
+    expect(res.statusCode).to.equal(200)
+  })
+})
 
 describe('Custom route options', () => {
-    it('Force a route to include pagination', async () => {
-        const options = {
-            routes: {
-                exclude: ['/enabled']
-            }
-        };
+  it('Force a route to include pagination', async () => {
+    const options = {
+      routes: {
+        exclude: ['/enabled']
+      }
+    }
 
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/enabled'
-        });
+    const res = await server.inject({
+      method: 'GET',
+      url: '/enabled'
+    })
 
-        const query = res.request.query;
-        expect(query.limit).to.equal(25);
-        expect(query.page).to.equal(1);
-    });
+    const query = res.request.query
+    expect(query.limit).to.equal(25)
+    expect(query.page).to.equal(1)
+  })
 
-    it('Force a route to exclude pagination', async () => {
-        const options = {
-            routes: {
-                include: ['/disabled']
-            }
-        };
+  it('Force a route to exclude pagination', async () => {
+    const options = {
+      routes: {
+        include: ['/disabled']
+      }
+    }
 
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/disabled'
-        });
+    const res = await server.inject({
+      method: 'GET',
+      url: '/disabled'
+    })
 
-        const query = res.request.query;
-        expect(query.limit).to.be.undefined();
-        expect(query.page).to.be.undefined();
-    });
-});
+    const query = res.request.query
+    expect(query.limit).to.be.undefined()
+    expect(query.page).to.be.undefined()
+  })
+})
 
 describe('Override on route level', () => {
-    it('Overriden defaults on route level with pagination to false', async () => {
-        const server = register();
+  it('Overriden defaults on route level with pagination to false', async () => {
+    const server = register()
 
-        await server.register(require(pluginName));
+    await server.register(require(pluginName))
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/defaults'
-        });
+    const res = await server.inject({
+      method: 'GET',
+      url: '/defaults'
+    })
 
-        expect(res.request.response.source).to.be.an.array();
-        expect(res.request.response.source).to.have.length(20);
-    });
+    expect(res.request.response.source).to.be.an.array()
+    expect(res.request.response.source).to.have.length(20)
+  })
 
-    it('Overriden defaults on route level with pagination to true', async () => {
-        const server = register();
+  it('Overriden defaults on route level with pagination to true', async () => {
+    const server = register()
 
-        await server.register(require(pluginName));
+    await server.register(require(pluginName))
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/defaults?pagination=true'
-        });
+    const res = await server.inject({
+      method: 'GET',
+      url: '/defaults?pagination=true'
+    })
 
-        const response = res.request.response.source;
-        expect(response).to.be.an.object();
-        expect(response.results).to.have.length(10);
-        expect(response.meta.totalCount).to.equal(20);
-        expect(res.request.query.limit).to.equal(10);
-        expect(res.request.query.page).to.equal(2);
-    });
+    const response = res.request.response.source
+    expect(response).to.be.an.object()
+    expect(response.results).to.have.length(10)
+    expect(response.meta.totalCount).to.equal(20)
+    expect(res.request.query.limit).to.equal(10)
+    expect(res.request.query.page).to.equal(2)
+  })
 
-    it('Overriden defaults on route level with limit and page to 5 and 1', async () => {
-        const server = register();
+  it('Overriden defaults on route level with limit and page to 5 and 1', async () => {
+    const server = register()
 
-        await server.register(require(pluginName));
+    await server.register(require(pluginName))
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/defaults?pagination=true&page=1&limit=5'
-        });
+    const res = await server.inject({
+      method: 'GET',
+      url: '/defaults?pagination=true&page=1&limit=5'
+    })
 
-        const response = res.request.response.source;
-        expect(response).to.be.an.object();
-        expect(response.results).to.have.length(5);
-        expect(response.meta.totalCount).to.equal(20);
-        expect(res.request.query.limit).to.equal(5);
-        expect(res.request.query.page).to.equal(1);
-    });
-});
+    const response = res.request.response.source
+    expect(response).to.be.an.object()
+    expect(response.results).to.have.length(5)
+    expect(response.meta.totalCount).to.equal(20)
+    expect(res.request.query.limit).to.equal(5)
+    expect(res.request.query.page).to.equal(1)
+  })
+})
 
 describe('Passing page and limit as query parameters', () => {
-    const options = {
+  const options = {
+    query: {
+      limit: {
+        default: 5,
+        name: 'myLimit'
+      },
+      page: {
+        default: 2,
+        name: 'myPage'
+      }
+    }
+  }
+
+  it('Passing limit', async () => {
+    const server = register()
+
+    server.register(require(pluginName))
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/?limit=5'
+    })
+
+    expect(res.request.query.limit).to.equal(5)
+    expect(res.request.query.page).to.equal(1)
+  })
+
+  it('Wrong limit and page should return the defaults', async () => {
+    const server = register()
+
+    await server.register(require(pluginName))
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/?limit=abc10&page=c2'
+    })
+
+    expect(res.request.query.limit).to.equal(25)
+    expect(res.request.query.page).to.equal(1)
+  })
+
+  it('Wrong limit with badRequest behavior should return 400 bad request', async () => {
+    const server = register()
+
+    await server.register({
+      plugin: require(pluginName),
+      options: {
         query: {
-            limit: {
-                default: 5,
-                name: 'myLimit'
-            },
-            page: {
-                default: 2,
-                name: 'myPage'
-            }
+          invalid: 'badRequest'
         }
-    };
+      }
+    })
 
-    it('Passing limit', async () => {
-        const server = register();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/?limit=abc10'
+    })
 
-        server.register(require(pluginName));
+    expect(res.request.response.source.statusCode).to.equal(400)
+    expect(res.request.response.statusCode).to.equal(400)
+  })
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/?limit=5'
-        });
+  it('Wrong page with badRequest behavior should return 400 bad request', async () => {
+    const server = register()
 
-        expect(res.request.query.limit).to.equal(5);
-        expect(res.request.query.page).to.equal(1);
-    });
+    await server.register({
+      plugin: require(pluginName),
+      options: {
+        query: {
+          invalid: 'badRequest'
+        }
+      }
+    })
 
-    it('Wrong limit and page should return the defaults', async () => {
-        const server = register();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/?page=abc10'
+    })
 
-        await server.register(require(pluginName));
+    expect(res.request.response.source.statusCode).to.equal(400)
+    expect(res.request.response.statusCode).to.equal(400)
+  })
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/?limit=abc10&page=c2'
-        });
+  it('Overriding and passing limit', async () => {
+    const server = register()
 
-        expect(res.request.query.limit).to.equal(25);
-        expect(res.request.query.page).to.equal(1);
-    });
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
 
-    it('Wrong limit with badRequest behavior should return 400 bad request', async () => {
-        const server = register();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/?myLimit=7'
+    })
 
-        await server.register({
-            plugin: require(pluginName),
-            options: {
-                query: {
-                    invalid: 'badRequest'
-                }
-            }
-        });
+    expect(res.request.query[options.query.limit.name]).to.equal(7)
+    expect(res.request.query[options.query.page.name]).to.equal(2)
+  })
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/?limit=abc10'
-        });
+  it('Passing page', async () => {
+    const server = register()
 
-        expect(res.request.response.source.statusCode).to.equal(400);
-        expect(res.request.response.statusCode).to.equal(400);
-    });
+    await server.register(require(pluginName))
 
-    it('Wrong page with badRequest behavior should return 400 bad request', async () => {
-        const server = register();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/?page=5'
+    })
 
-        await server.register({
-            plugin: require(pluginName),
-            options: {
-                query: {
-                    invalid: 'badRequest'
-                }
-            }
-        });
+    expect(res.request.query.page).to.equal(5)
+  })
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/?page=abc10'
-        });
+  it('Overriding and passing page', async () => {
+    const server = register()
 
-        expect(res.request.response.source.statusCode).to.equal(400);
-        expect(res.request.response.statusCode).to.equal(400);
-    });
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
 
-    it('Overriding and passing limit', async () => {
-        const server = register();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/?myPage=5'
+    })
 
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/?myLimit=7'
-        });
-
-        expect(res.request.query[options.query.limit.name]).to.equal(7);
-        expect(res.request.query[options.query.page.name]).to.equal(2);
-    });
-
-    it('Passing page', async () => {
-        const server = register();
-
-        await server.register(require(pluginName));
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/?page=5'
-        });
-
-        expect(res.request.query.page).to.equal(5);
-    });
-
-    it('Overriding and passing page', async () => {
-        const server = register();
-
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
-
-        const res = await server.inject({
-            method: 'GET',
-            url: '/?myPage=5'
-        });
-
-        expect(res.request.query[options.query.limit.name]).to.equal(5);
-        expect(res.request.query[options.query.page.name]).to.equal(5);
-    });
-});
+    expect(res.request.query[options.query.limit.name]).to.equal(5)
+    expect(res.request.query[options.query.page.name]).to.equal(5)
+  })
+})
 
 describe('Test /users route', () => {
-    it('Test default with totalCount added to request object', async () => {
-        const urlForPage = (page) => [
-            `http://localhost/users?page=${page}&limit=5`
-        ];
+  it('Test default with totalCount added to request object', async () => {
+    const urlForPage = (page) => [`http://localhost/users?page=${page}&limit=5`]
 
-        const server = register();
-        await server.register(require(pluginName));
+    const server = register()
+    await server.register(require(pluginName))
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/users?page=2&limit=5'
-        });
+    const res = await server.inject({
+      method: 'GET',
+      url: '/users?page=2&limit=5'
+    })
 
-        const response = res.request.response.source;
-        const meta = response.meta;
-        expect(meta).to.be.an.object();
-        expect(meta.count).to.equal(5);
-        expect(meta.totalCount).to.equal(20);
-        expect(meta.pageCount).to.equal(4);
-        expect(meta.previous).to.part.include(urlForPage(1));
-        expect(meta.next).to.part.include(urlForPage(3));
-        expect(meta.last).to.part.include(urlForPage(4));
-        expect(meta.first).to.part.include(urlForPage(1));
-        expect(meta.self).to.part.include(urlForPage(2));
+    const response = res.request.response.source
+    const meta = response.meta
+    expect(meta).to.be.an.object()
+    expect(meta.count).to.equal(5)
+    expect(meta.totalCount).to.equal(20)
+    expect(meta.pageCount).to.equal(4)
+    expect(meta.previous).to.part.include(urlForPage(1))
+    expect(meta.next).to.part.include(urlForPage(3))
+    expect(meta.last).to.part.include(urlForPage(4))
+    expect(meta.first).to.part.include(urlForPage(1))
+    expect(meta.self).to.part.include(urlForPage(2))
 
-        expect(response.results).to.be.an.array();
-        expect(response.results).to.have.length(5);
-    });
+    expect(response.results).to.be.an.array()
+    expect(response.results).to.have.length(5)
+  })
 
-    it('Test that hasNext, related links behave correctly', async () => {
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options: {
-                meta: {
-                    hasNext: {
-                        active: true
-                    },
-                    next: {
-                        active: true
-                    }
-                }
-            }
-        });
+  it('Test that hasNext, related links behave correctly', async () => {
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options: {
+        meta: {
+          hasNext: {
+            active: true
+          },
+          next: {
+            active: true
+          }
+        }
+      }
+    })
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/users?page=4&limit=5'
-        });
-        const response = res.request.response.source;
-        const meta = response.meta;
-        expect(meta.hasNext).to.equal(false);
-        expect(meta.next).to.be.null();
-        expect(meta.first).to.equal('http://localhost/users?page=1&limit=5');
-        expect(meta.last).to.equal('http://localhost/users?page=4&limit=5');
-        expect(meta.self).to.equal('http://localhost/users?page=4&limit=5');
-    });
+    const res = await server.inject({
+      method: 'GET',
+      url: '/users?page=4&limit=5'
+    })
+    const response = res.request.response.source
+    const meta = response.meta
+    expect(meta.hasNext).to.equal(false)
+    expect(meta.next).to.be.null()
+    expect(meta.first).to.equal('http://localhost/users?page=1&limit=5')
+    expect(meta.last).to.equal('http://localhost/users?page=4&limit=5')
+    expect(meta.self).to.equal('http://localhost/users?page=4&limit=5')
+  })
 
-    it('Test that hasNext, related links behave correctly with zero index', async () => {
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options: {
-                zeroIndex: true,
-                meta: {
-                    hasNext: {
-                        active: true
-                    },
-                    next: {
-                        active: true
-                    }
-                }
-            }
-        });
+  it('Test that hasNext, related links behave correctly with zero index', async () => {
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options: {
+        zeroIndex: true,
+        meta: {
+          hasNext: {
+            active: true
+          },
+          next: {
+            active: true
+          }
+        }
+      }
+    })
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/users?page=3&limit=5'
-        });
-        const response = res.request.response.source;
-        const meta = response.meta;
-        expect(meta.hasNext).to.equal(false);
-        expect(meta.next).to.be.null();
-        expect(meta.first).to.equal('http://localhost/users?page=0&limit=5');
-        expect(meta.last).to.equal('http://localhost/users?page=3&limit=5');
-        expect(meta.self).to.equal('http://localhost/users?page=3&limit=5');
-    });
+    const res = await server.inject({
+      method: 'GET',
+      url: '/users?page=3&limit=5'
+    })
+    const response = res.request.response.source
+    const meta = response.meta
+    expect(meta.hasNext).to.equal(false)
+    expect(meta.next).to.be.null()
+    expect(meta.first).to.equal('http://localhost/users?page=0&limit=5')
+    expect(meta.last).to.equal('http://localhost/users?page=3&limit=5')
+    expect(meta.self).to.equal('http://localhost/users?page=3&limit=5')
+  })
 
-    it('Test that hasPrev, related links behave correctly', async () => {
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options: {
-                meta: {
-                    hasPrevious: {
-                        active: true
-                    },
-                    previous: {
-                        active: true
-                    }
-                }
-            }
-        });
+  it('Test that hasPrev, related links behave correctly', async () => {
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options: {
+        meta: {
+          hasPrevious: {
+            active: true
+          },
+          previous: {
+            active: true
+          }
+        }
+      }
+    })
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/users?page=1&limit=5'
-        });
-        const response = res.request.response.source;
-        const meta = response.meta;
-        expect(meta.hasPrevious).to.equal(false);
-        expect(meta.previous).to.be.null();
-        expect(meta.first).to.equal('http://localhost/users?page=1&limit=5');
-        expect(meta.last).to.equal('http://localhost/users?page=4&limit=5');
-        expect(meta.self).to.equal('http://localhost/users?page=1&limit=5');
-    });
+    const res = await server.inject({
+      method: 'GET',
+      url: '/users?page=1&limit=5'
+    })
+    const response = res.request.response.source
+    const meta = response.meta
+    expect(meta.hasPrevious).to.equal(false)
+    expect(meta.previous).to.be.null()
+    expect(meta.first).to.equal('http://localhost/users?page=1&limit=5')
+    expect(meta.last).to.equal('http://localhost/users?page=4&limit=5')
+    expect(meta.self).to.equal('http://localhost/users?page=1&limit=5')
+  })
 
-    it('Test that hasPrev, related links behave correctly with zero index', async () => {
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options: {
-                zeroIndex: true,
-                meta: {
-                    hasPrevious: {
-                        active: true
-                    },
-                    previous: {
-                        active: true
-                    }
-                }
-            }
-        });
+  it('Test that hasPrev, related links behave correctly with zero index', async () => {
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options: {
+        zeroIndex: true,
+        meta: {
+          hasPrevious: {
+            active: true
+          },
+          previous: {
+            active: true
+          }
+        }
+      }
+    })
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/users?page=0&limit=5'
-        });
-        const response = res.request.response.source;
-        const meta = response.meta;
-        expect(meta.hasPrevious).to.equal(false);
-        expect(meta.previous).to.equal(null);
-        expect(meta.first).to.equal('http://localhost/users?page=0&limit=5');
-        expect(meta.last).to.equal('http://localhost/users?page=3&limit=5');
-        expect(meta.self).to.equal('http://localhost/users?page=0&limit=5');
-    });
-});
+    const res = await server.inject({
+      method: 'GET',
+      url: '/users?page=0&limit=5'
+    })
+    const response = res.request.response.source
+    const meta = response.meta
+    expect(meta.hasPrevious).to.equal(false)
+    expect(meta.previous).to.equal(null)
+    expect(meta.first).to.equal('http://localhost/users?page=0&limit=5')
+    expect(meta.last).to.equal('http://localhost/users?page=3&limit=5')
+    expect(meta.self).to.equal('http://localhost/users?page=0&limit=5')
+  })
+})
 
 describe('Testing pageCount', () => {
-    it('Limit is 3, page should be 7', async () => {
-        const server = register();
-        await server.register(require(pluginName));
+  it('Limit is 3, page should be 7', async () => {
+    const server = register()
+    await server.register(require(pluginName))
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/users?limit=3'
-        });
+    const res = await server.inject({
+      method: 'GET',
+      url: '/users?limit=3'
+    })
 
-        const response = res.request.response.source;
-        const meta = response.meta;
+    const response = res.request.response.source
+    const meta = response.meta
 
-        expect(meta.pageCount).to.equal(7);
-    });
+    expect(meta.pageCount).to.equal(7)
+  })
 
-    it('Limit is 4, page should be 5', async () => {
-        const server = register();
-        await server.register(require(pluginName));
+  it('Limit is 4, page should be 5', async () => {
+    const server = register()
+    await server.register(require(pluginName))
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/users?limit=4'
-        });
+    const res = await server.inject({
+      method: 'GET',
+      url: '/users?limit=4'
+    })
 
-        const response = res.request.response.source;
-        const meta = response.meta;
+    const response = res.request.response.source
+    const meta = response.meta
 
-        expect(meta.pageCount).to.equal(5);
-    });
+    expect(meta.pageCount).to.equal(5)
+  })
 
-    it('Limit is 1, page should be 20', async () => {
-        const server = register();
-        await server.register(require(pluginName));
+  it('Limit is 1, page should be 20', async () => {
+    const server = register()
+    await server.register(require(pluginName))
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/users?limit=1'
-        });
+    const res = await server.inject({
+      method: 'GET',
+      url: '/users?limit=1'
+    })
 
-        const response = res.request.response.source;
-        const meta = response.meta;
+    const response = res.request.response.source
+    const meta = response.meta
 
-        expect(meta.pageCount).to.equal(20);
-    });
-});
+    expect(meta.pageCount).to.equal(20)
+  })
+})
 
 describe('Post request', () => {
-    it('Should work with a post request', async () => {
-        const server = register();
-        await server.register(require(pluginName));
+  it('Should work with a post request', async () => {
+    const server = register()
+    await server.register(require(pluginName))
 
-        const res = await server.inject({
-            method: 'POST',
-            url: '/users'
-        });
+    const res = await server.inject({
+      method: 'POST',
+      url: '/users'
+    })
 
-        const response = res.request.response.source;
+    const response = res.request.response.source
 
-        expect(response).to.equal('Works');
-    });
-});
+    expect(response).to.equal('Works')
+  })
+})
 
 describe('Changing pagination query parameter', () => {
-    it('Should return the results with no pagination', async () => {
-        const server = register();
-        await server.register(require(pluginName));
+  it('Should return the results with no pagination', async () => {
+    const server = register()
+    await server.register(require(pluginName))
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/?pagination=false'
-        });
+    const res = await server.inject({
+      method: 'GET',
+      url: '/?pagination=false'
+    })
 
-        const response = res.request.response.source;
-        expect(response).to.be.an.array();
-    });
+    const response = res.request.response.source
+    expect(response).to.be.an.array()
+  })
 
-    it('Pagination to random value (default is true)', async () => {
-        const server = register();
-        await server.register(require(pluginName));
+  it('Pagination to random value (default is true)', async () => {
+    const server = register()
+    await server.register(require(pluginName))
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/?pagination=abcd'
-        });
+    const res = await server.inject({
+      method: 'GET',
+      url: '/?pagination=abcd'
+    })
 
-        const response = res.request.response.source;
-        expect(response.meta).to.be.an.object();
-        expect(response.results).to.be.an.array();
-    });
+    const response = res.request.response.source
+    expect(response.meta).to.be.an.object()
+    expect(response.results).to.be.an.array()
+  })
 
-    it('Pagination to random value (default is false)', async () => {
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options: {
-                query: {
-                    pagination: {
-                        default: false
-                    }
-                }
-            }
-        });
+  it('Pagination to random value (default is false)', async () => {
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options: {
+        query: {
+          pagination: {
+            default: false
+          }
+        }
+      }
+    })
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/?pagination=abcd'
-        });
+    const res = await server.inject({
+      method: 'GET',
+      url: '/?pagination=abcd'
+    })
 
-        const response = res.request.response.source;
-        expect(response).to.be.an.array();
-    });
+    const response = res.request.response.source
+    expect(response).to.be.an.array()
+  })
 
-    it('Pagination explicitely to true', async () => {
-        const options = {
-            meta: {
-                name: 'myMeta',
-                count: {
-                    active: true,
-                    name: 'myCount'
-                },
-                totalCount: {
-                    active: true,
-                    name: 'myTotalCount'
-                },
-                pageCount: {
-                    active: true,
-                    name: 'myPageCount'
-                },
-                self: {
-                    active: true,
-                    name: 'mySelf'
-                },
-                previous: {
-                    active: true,
-                    name: 'myPrevious'
-                },
-                next: {
-                    active: true,
-                    name: 'myNext'
-                },
-                hasNext: {
-                    active: true,
-                    name: 'myHasNext'
-                },
-                hasPrevious: {
-                    active: true,
-                    name: 'myHasPrevious'
-                },
-                first: {
-                    active: true,
-                    name: 'myFirst'
-                },
-                last: {
-                    active: true,
-                    name: 'myLast'
-                },
-                limit: {
-                    active: true
-                },
-                page: {
-                    active: true
-                }
-            }
-        };
+  it('Pagination explicitely to true', async () => {
+    const options = {
+      meta: {
+        name: 'myMeta',
+        count: {
+          active: true,
+          name: 'myCount'
+        },
+        totalCount: {
+          active: true,
+          name: 'myTotalCount'
+        },
+        pageCount: {
+          active: true,
+          name: 'myPageCount'
+        },
+        self: {
+          active: true,
+          name: 'mySelf'
+        },
+        previous: {
+          active: true,
+          name: 'myPrevious'
+        },
+        next: {
+          active: true,
+          name: 'myNext'
+        },
+        hasNext: {
+          active: true,
+          name: 'myHasNext'
+        },
+        hasPrevious: {
+          active: true,
+          name: 'myHasPrevious'
+        },
+        first: {
+          active: true,
+          name: 'myFirst'
+        },
+        last: {
+          active: true,
+          name: 'myLast'
+        },
+        limit: {
+          active: true
+        },
+        page: {
+          active: true
+        }
+      }
+    }
 
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
-        const res = await server.inject({
-            method: 'GET',
-            url: '/?pagination=true'
-        });
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
+    const res = await server.inject({
+      method: 'GET',
+      url: '/?pagination=true'
+    })
 
-        const response = res.request.response.source;
-        const names = options.meta;
+    const response = res.request.response.source
+    const names = options.meta
 
-        const meta = response[names.name];
-        expect(meta).to.be.an.object();
-        expect(meta.limit).to.equal(25);
-        expect(meta.page).to.equal(1);
-        expect(meta[names.count.name]).to.equal(0);
-        expect(meta[names.totalCount.name]).to.be.null();
-        expect(meta[names.pageCount.name]).to.be.null();
-        expect(meta[names.previous.name]).to.be.null();
-        expect(meta[names.next.name]).to.be.null();
-        expect(meta[names.hasNext.name]).to.be.false();
-        expect(meta[names.hasPrevious.name]).to.be.false();
-        expect(meta[names.last.name]).to.be.null();
-        expect(meta[names.first.name]).to.part.include([
-            'http://localhost/?',
-            ' page=1',
-            '&',
-            'limit=25'
-        ]);
-        expect(meta[names.self.name]).to.part.include([
-            'http://localhost/?',
-            'page=1',
-            '&',
-            'limit=25'
-        ]);
-        expect(response.results).to.be.an.array();
-        expect(response.results).to.have.length(0);
-    });
+    const meta = response[names.name]
+    expect(meta).to.be.an.object()
+    expect(meta.limit).to.equal(25)
+    expect(meta.page).to.equal(1)
+    expect(meta[names.count.name]).to.equal(0)
+    expect(meta[names.totalCount.name]).to.be.null()
+    expect(meta[names.pageCount.name]).to.be.null()
+    expect(meta[names.previous.name]).to.be.null()
+    expect(meta[names.next.name]).to.be.null()
+    expect(meta[names.hasNext.name]).to.be.false()
+    expect(meta[names.hasPrevious.name]).to.be.false()
+    expect(meta[names.last.name]).to.be.null()
+    expect(meta[names.first.name]).to.part.include([
+      'http://localhost/?',
+      ' page=1',
+      '&',
+      'limit=25'
+    ])
+    expect(meta[names.self.name]).to.part.include([
+      'http://localhost/?',
+      'page=1',
+      '&',
+      'limit=25'
+    ])
+    expect(response.results).to.be.an.array()
+    expect(response.results).to.have.length(0)
+  })
 
-    it('Pagination default is false', async () => {
-        const options = {
-            query: {
-                pagination: {
-                    default: false
-                }
-            },
-            meta: {
-                name: 'myMeta',
-                count: {
-                    active: true,
-                    name: 'myCount'
-                },
-                totalCount: {
-                    active: true,
-                    name: 'myTotalCount'
-                },
-                pageCount: {
-                    active: true,
-                    name: 'myPageCount'
-                },
-                self: {
-                    active: true,
-                    name: 'mySelf'
-                },
-                previous: {
-                    active: true,
-                    name: 'myPrevious'
-                },
-                next: {
-                    active: true,
-                    name: 'myNext'
-                },
-                hasNext: {
-                    active: true,
-                    name: 'myHasNext'
-                },
-                hasPrevious: {
-                    active: true,
-                    name: 'myHasPrevious'
-                },
-                first: {
-                    active: true,
-                    name: 'myFirst'
-                },
-                last: {
-                    active: true,
-                    name: 'myLast'
-                },
-                limit: {
-                    active: true
-                },
-                page: {
-                    active: true
-                }
-            }
-        };
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
+  it('Pagination default is false', async () => {
+    const options = {
+      query: {
+        pagination: {
+          default: false
+        }
+      },
+      meta: {
+        name: 'myMeta',
+        count: {
+          active: true,
+          name: 'myCount'
+        },
+        totalCount: {
+          active: true,
+          name: 'myTotalCount'
+        },
+        pageCount: {
+          active: true,
+          name: 'myPageCount'
+        },
+        self: {
+          active: true,
+          name: 'mySelf'
+        },
+        previous: {
+          active: true,
+          name: 'myPrevious'
+        },
+        next: {
+          active: true,
+          name: 'myNext'
+        },
+        hasNext: {
+          active: true,
+          name: 'myHasNext'
+        },
+        hasPrevious: {
+          active: true,
+          name: 'myHasPrevious'
+        },
+        first: {
+          active: true,
+          name: 'myFirst'
+        },
+        last: {
+          active: true,
+          name: 'myLast'
+        },
+        limit: {
+          active: true
+        },
+        page: {
+          active: true
+        }
+      }
+    }
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/?pagination=true'
-        });
+    const res = await server.inject({
+      method: 'GET',
+      url: '/?pagination=true'
+    })
 
-        const response = res.request.response.source;
-        const names = options.meta;
+    const response = res.request.response.source
+    const names = options.meta
 
-        const meta = response[names.name];
-        expect(meta).to.be.an.object();
-        expect(meta.limit).to.equal(25);
-        expect(meta.page).to.equal(1);
-        expect(meta[names.count.name]).to.equal(0);
-        expect(meta[names.totalCount.name]).to.be.null();
-        expect(meta[names.pageCount.name]).to.be.null();
-        expect(meta[names.previous.name]).to.be.null();
-        expect(meta[names.next.name]).to.be.null();
-        expect(meta[names.hasNext.name]).to.be.false();
-        expect(meta[names.hasPrevious.name]).to.be.false();
-        expect(meta[names.last.name]).to.be.null();
-        expect(meta[names.first.name]).to.part.include(['pagination=true']);
-        expect(meta[names.self.name]).to.part.include(['pagination=true']);
-        expect(response.results).to.be.an.array();
-        expect(response.results).to.have.length(0);
-    });
-});
+    const meta = response[names.name]
+    expect(meta).to.be.an.object()
+    expect(meta.limit).to.equal(25)
+    expect(meta.page).to.equal(1)
+    expect(meta[names.count.name]).to.equal(0)
+    expect(meta[names.totalCount.name]).to.be.null()
+    expect(meta[names.pageCount.name]).to.be.null()
+    expect(meta[names.previous.name]).to.be.null()
+    expect(meta[names.next.name]).to.be.null()
+    expect(meta[names.hasNext.name]).to.be.false()
+    expect(meta[names.hasPrevious.name]).to.be.false()
+    expect(meta[names.last.name]).to.be.null()
+    expect(meta[names.first.name]).to.part.include(['pagination=true'])
+    expect(meta[names.self.name]).to.part.include(['pagination=true'])
+    expect(response.results).to.be.an.array()
+    expect(response.results).to.have.length(0)
+  })
+})
 
 describe('Wrong options', () => {
-    it('Should return an error on register', async () => {
-        const server = register();
-        const serverRegister = async () => {
-            await server.register({
-                plugin: require(pluginName),
-                options: {
-                    query: {
-                        limit: {
-                            default: 'abcd'
-                        }
-                    }
-                }
-            });
-        };
-
-        await expect(serverRegister()).to.reject();
-    });
-
-    it('Should return an error on register', async () => {
-        const server = register();
-
-        const serverRegister = async () => {
-            await server.register({
-                plugin: require(pluginName),
-                options: {
-                    meta: {
-                        name: 0
-                    }
-                }
-            });
-        };
-
-        await expect(serverRegister()).to.reject();
-    });
-
-    it('Should return an error on register', async () => {
-        const server = register();
-
-        const serverRegister = async () => {
-            await server.register({
-                plugin: require(pluginName),
-                options: {
-                    query: {
-                        limit: {
-                            default: 0
-                        }
-                    }
-                }
-            });
-        };
-
-        await expect(serverRegister()).to.reject();
-    });
-
-    it('Should return an error on register', async () => {
-        const server = register();
-
-        const serverRegister = async () => {
-            await server.register({
-                plugin: require(pluginName),
-                options: {
-                    meta: {
-                        totalCount: {
-                            active: 'abc'
-                        }
-                    }
-                }
-            });
-        };
-
-        await expect(serverRegister()).to.reject();
-    });
-
-    it('Should return an error on paginate', async () => {
-        const server = register();
-        await server.register(require(pluginName));
-        server.route({
-            method: 'GET',
-            path: '/error',
-            handler: (request, h) => {
-                return h.paginate([1, 2], 0, { key: 1 });
+  it('Should return an error on register', async () => {
+    const server = register()
+    const serverRegister = async () => {
+      await server.register({
+        plugin: require(pluginName),
+        options: {
+          query: {
+            limit: {
+              default: 'abcd'
             }
-        });
+          }
+        }
+      })
+    }
 
-        const request = {
-            method: 'GET',
-            url: '/error'
-        };
+    await expect(serverRegister()).to.reject()
+  })
 
-        const res = await server.inject(request);
-        expect(res.request.response.statusCode).to.equal(500);
-    });
-});
+  it('Should return an error on register', async () => {
+    const server = register()
+
+    const serverRegister = async () => {
+      await server.register({
+        plugin: require(pluginName),
+        options: {
+          meta: {
+            name: 0
+          }
+        }
+      })
+    }
+
+    await expect(serverRegister()).to.reject()
+  })
+
+  it('Should return an error on register', async () => {
+    const server = register()
+
+    const serverRegister = async () => {
+      await server.register({
+        plugin: require(pluginName),
+        options: {
+          query: {
+            limit: {
+              default: 0
+            }
+          }
+        }
+      })
+    }
+
+    await expect(serverRegister()).to.reject()
+  })
+
+  it('Should return an error on register', async () => {
+    const server = register()
+
+    const serverRegister = async () => {
+      await server.register({
+        plugin: require(pluginName),
+        options: {
+          meta: {
+            totalCount: {
+              active: 'abc'
+            }
+          }
+        }
+      })
+    }
+
+    await expect(serverRegister()).to.reject()
+  })
+
+  it('Should return an error on paginate', async () => {
+    const server = register()
+    await server.register(require(pluginName))
+    server.route({
+      method: 'GET',
+      path: '/error',
+      handler: (request, h) => {
+        return h.paginate([1, 2], 0, { key: 1 })
+      }
+    })
+
+    const request = {
+      method: 'GET',
+      url: '/error'
+    }
+
+    const res = await server.inject(request)
+    expect(res.request.response.statusCode).to.equal(500)
+  })
+})
 
 describe('Results with other keys', () => {
-    it('Should return the response with the original response keys', async () => {
-        const server = register();
-        await server.register(require(pluginName));
+  it('Should return the response with the original response keys', async () => {
+    const server = register()
+    await server.register(require(pluginName))
 
-        const request = {
-            method: 'GET',
-            url: '/users2'
-        };
+    const request = {
+      method: 'GET',
+      url: '/users2'
+    }
 
-        const res = await server.inject(request);
+    const res = await server.inject(request)
 
-        const response = res.request.response.source;
-        expect(response.otherKey).to.equal('otherKey');
-        expect(response.otherKey2).to.equal('otherKey2');
-        expect(response.meta).to.exists();
-        expect(response.results).to.exists();
-    });
+    const response = res.request.response.source
+    expect(response.otherKey).to.equal('otherKey')
+    expect(response.otherKey2).to.equal('otherKey2')
+    expect(response.meta).to.exists()
+    expect(response.results).to.exists()
+  })
 
-    it('Should return an internal server error', async () => {
-        const server = register();
+  it('Should return an internal server error', async () => {
+    const server = register()
 
-        await server.register(require(pluginName));
+    await server.register(require(pluginName))
 
-        server.route({
-            method: 'GET',
-            path: '/error',
-            handler: (request, h) => {
-                return h.paginate({ results: [] }, 0);
-            }
-        });
+    server.route({
+      method: 'GET',
+      path: '/error',
+      handler: (request, h) => {
+        return h.paginate({ results: [] }, 0)
+      }
+    })
 
-        const request = {
-            method: 'GET',
-            url: '/error'
-        };
+    const request = {
+      method: 'GET',
+      url: '/error'
+    }
 
-        const res = await server.inject(request);
+    const res = await server.inject(request)
 
-        expect(res.request.response.statusCode).to.equal(500);
-    });
+    expect(res.request.response.statusCode).to.equal(500)
+  })
 
-    it('Should return an internal server error #2', async () => {
-        const server = register();
+  it('Should return an internal server error #2', async () => {
+    const server = register()
 
-        await server.register(require(pluginName));
+    await server.register(require(pluginName))
 
-        server.route({
-            method: 'GET',
-            path: '/error',
-            handler: (request, h) => {
-                return h.paginate({ results: [] }, 0, { key: 'res' });
-            }
-        });
+    server.route({
+      method: 'GET',
+      path: '/error',
+      handler: (request, h) => {
+        return h.paginate({ results: [] }, 0, { key: 'res' })
+      }
+    })
 
-        const request = {
-            method: 'GET',
-            url: '/error'
-        };
+    const request = {
+      method: 'GET',
+      url: '/error'
+    }
 
-        const res = await server.inject(request);
+    const res = await server.inject(request)
 
-        expect(res.request.response.statusCode).to.equal(500);
-    });
+    expect(res.request.response.statusCode).to.equal(500)
+  })
 
-    it('Should not override meta and results', async () => {
-        const server = register();
+  it('Should not override meta and results', async () => {
+    const server = register()
 
-        await server.register(require(pluginName));
+    await server.register(require(pluginName))
 
-        server.route({
-            method: 'GET',
-            path: '/nooverride',
-            handler: (request, h) => {
-                return h.paginate(
-                    { res: [], results: 'results', meta: 'meta' },
-                    0,
-                    { key: 'res' }
-                );
-            }
-        });
+    server.route({
+      method: 'GET',
+      path: '/nooverride',
+      handler: (request, h) => {
+        return h.paginate({ res: [], results: 'results', meta: 'meta' }, 0, {
+          key: 'res'
+        })
+      }
+    })
 
-        const request = {
-            method: 'GET',
-            url: '/nooverride'
-        };
+    const request = {
+      method: 'GET',
+      url: '/nooverride'
+    }
 
-        const res = await server.inject(request);
+    const res = await server.inject(request)
 
-        const response = res.request.response.source;
-        expect(response.meta).to.not.equal('meta');
-        expect(response.results).to.not.equal('results');
-    });
-});
+    const response = res.request.response.source
+    expect(response.meta).to.not.equal('meta')
+    expect(response.results).to.not.equal('results')
+  })
+})
 
 describe('Empty result set', () => {
-    it('Counts should be 0', async () => {
-        const server = register();
-        await server.register(require(pluginName));
+  it('Counts should be 0', async () => {
+    const server = register()
+    await server.register(require(pluginName))
 
-        const request = {
-            method: 'GET',
-            url: '/empty'
-        };
+    const request = {
+      method: 'GET',
+      url: '/empty'
+    }
 
-        const res = await server.inject(request);
+    const res = await server.inject(request)
 
-        const response = res.request.response.source;
-        expect(response.meta.totalCount).to.equal(0);
-        expect(response.meta.pageCount).to.equal(0);
-        expect(response.meta.count).to.equal(0);
-    });
+    const response = res.request.response.source
+    expect(response.meta.totalCount).to.equal(0)
+    expect(response.meta.pageCount).to.equal(0)
+    expect(response.meta.count).to.equal(0)
+  })
 
-    it('Staus code should be >=200 & <=299', async () => {
-        const server = register();
-        await server.register(require(pluginName));
+  it('Staus code should be >=200 & <=299', async () => {
+    const server = register()
+    await server.register(require(pluginName))
 
-        const request = {
-            method: 'GET',
-            url: '/empty'
-        };
+    const request = {
+      method: 'GET',
+      url: '/empty'
+    }
 
-        const res = await server.inject(request);
+    const res = await server.inject(request)
 
-        const response = res.request.response;
-        expect(response.statusCode).to.be.greaterThan(199);
-        expect(response.statusCode).to.be.lessThan(300);
-    });
-});
+    const response = res.request.response
+    expect(response.statusCode).to.be.greaterThan(199)
+    expect(response.statusCode).to.be.lessThan(300)
+  })
+})
 
 describe('Exception', () => {
-    it('Should not continue on exception', async () => {
-        const server = register();
-        await server.register(require(pluginName));
-        const request = {
-            method: 'GET',
-            url: '/exception'
-        };
+  it('Should not continue on exception', async () => {
+    const server = register()
+    await server.register(require(pluginName))
+    const request = {
+      method: 'GET',
+      url: '/exception'
+    }
 
-        const res = await server.inject(request);
-        expect(res.request.response.statusCode).to.equal(500);
-    });
+    const res = await server.inject(request)
+    expect(res.request.response.statusCode).to.equal(500)
+  })
 
-    it('Should not process further if response code is not in 200 - 299 range', async () => {
-        const server = register();
-        await server.register(require(pluginName));
-        const request = {
-            method: 'GET',
-            url: '/array-exception'
-        };
+  it('Should not process further if response code is not in 200 - 299 range', async () => {
+    const server = register()
+    await server.register(require(pluginName))
+    const request = {
+      method: 'GET',
+      url: '/array-exception'
+    }
 
-        const res = await server.inject(request);
+    const res = await server.inject(request)
 
-        const response = res.request.response.source;
-        const message = response.message;
-        expect(message).to.equal('Custom Error Message');
-        expect(res.request.response.statusCode).to.equal(500);
-    });
+    const response = res.request.response.source
+    const message = response.message
+    expect(message).to.equal('Custom Error Message')
+    expect(res.request.response.statusCode).to.equal(500)
+  })
 
-    it('Should not process further if upgrade request is received', async () => {
-        const server = register();
-        await server.register(require(pluginName));
+  it('Should not process further if upgrade request is received', async () => {
+    const server = register()
+    await server.register(require(pluginName))
 
-        const request = {
-            method: 'GET',
-            url: '/ws-upgrade'
-        };
+    const request = {
+      method: 'GET',
+      url: '/ws-upgrade'
+    }
 
-        const res = await server.inject(request);
-        expect(res.request.response.statusCode).to.equal(101);
-    });
-});
+    const res = await server.inject(request)
+    expect(res.request.response.statusCode).to.equal(101)
+  })
+})
 
 describe('Override on route level error', () => {
-    it('Should return an error', async () => {
-        const server = register();
-        server.route({
-            path: '/error',
-            method: 'GET',
-            config: {
-                plugins: {
-                    pagination: {
-                        defaults: {
-                            limit: 'a'
-                        }
-                    }
-                },
-                handler: (request, h) => {
-                    return;
-                }
+  it('Should return an error', async () => {
+    const server = register()
+    server.route({
+      path: '/error',
+      method: 'GET',
+      config: {
+        plugins: {
+          pagination: {
+            defaults: {
+              limit: 'a'
             }
-        });
+          }
+        },
+        handler: (request, h) => {
+          return
+        }
+      }
+    })
 
-        const serverRegister = async () => {
-            await server.register(require(pluginName));
-        };
+    const serverRegister = async () => {
+      await server.register(require(pluginName))
+    }
 
-        await expect(serverRegister()).to.reject();
-    });
+    await expect(serverRegister()).to.reject()
+  })
 
-    it('Should return an error', async () => {
-        const server = register();
-        server.route({
-            path: '/error',
-            method: 'GET',
-            config: {
-                plugins: {
-                    pagination: {
-                        defaults: {
-                            page: 'a'
-                        }
-                    }
-                },
-                handler: (request, h) => h()
+  it('Should return an error', async () => {
+    const server = register()
+    server.route({
+      path: '/error',
+      method: 'GET',
+      config: {
+        plugins: {
+          pagination: {
+            defaults: {
+              page: 'a'
             }
-        });
+          }
+        },
+        handler: (request, h) => h()
+      }
+    })
 
-        const serverRegister = async () => {
-            await server.register(require(pluginName));
-        };
+    const serverRegister = async () => {
+      await server.register(require(pluginName))
+    }
 
-        await expect(serverRegister()).to.reject();
-    });
+    await expect(serverRegister()).to.reject()
+  })
 
-    it('Should return an error', async () => {
-        const server = register();
-        server.route({
-            path: '/error',
-            method: 'GET',
-            config: {
-                plugins: {
-                    pagination: {
-                        defaults: {
-                            pagination: 'a'
-                        }
-                    }
-                },
-                handler: (request, h) => h()
+  it('Should return an error', async () => {
+    const server = register()
+    server.route({
+      path: '/error',
+      method: 'GET',
+      config: {
+        plugins: {
+          pagination: {
+            defaults: {
+              pagination: 'a'
             }
-        });
+          }
+        },
+        handler: (request, h) => h()
+      }
+    })
 
-        const serverRegister = async () => {
-            await server.register(require(pluginName));
-        };
+    const serverRegister = async () => {
+      await server.register(require(pluginName))
+    }
 
-        await expect(serverRegister()).to.reject();
-    });
+    await expect(serverRegister()).to.reject()
+  })
 
-    it('Should return an error', async () => {
-        const server = register();
-        server.route({
-            path: '/error',
-            method: 'GET',
-            config: {
-                plugins: {
-                    pagination: {
-                        enabled: 'a'
-                    }
-                },
-                handler: (request, h) => h()
-            }
-        });
+  it('Should return an error', async () => {
+    const server = register()
+    server.route({
+      path: '/error',
+      method: 'GET',
+      config: {
+        plugins: {
+          pagination: {
+            enabled: 'a'
+          }
+        },
+        handler: (request, h) => h()
+      }
+    })
 
-        const serverRegister = async () => {
-            await server.register(require(pluginName));
-        };
+    const serverRegister = async () => {
+      await server.register(require(pluginName))
+    }
 
-        await expect(serverRegister()).to.reject();
-    });
-});
+    await expect(serverRegister()).to.reject()
+  })
+})
 
 describe('Empty baseUri should give relative url', () => {
-    it('use custom baseUri instead of server provided uri', async () => {
-        const options = {
-            meta: {
-                baseUri: ''
-            }
-        };
+  it('use custom baseUri instead of server provided uri', async () => {
+    const options = {
+      meta: {
+        baseUri: ''
+      }
+    }
 
-        const urlForPage = (page) => [
-            '/users?',
-            `page=${page}`,
-            '&',
-            'limit=5'
-        ];
+    const urlForPage = (page) => ['/users?', `page=${page}`, '&', 'limit=5']
 
-        const server = register();
-        await server.register({
-            plugin: require(pluginName),
-            options
-        });
+    const server = register()
+    await server.register({
+      plugin: require(pluginName),
+      options
+    })
 
-        const res = await server.inject({
-            method: 'GET',
-            url: '/users?limit=5'
-        });
+    const res = await server.inject({
+      method: 'GET',
+      url: '/users?limit=5'
+    })
 
-        const response = res.request.response.source;
-        const meta = response.meta;
-        expect(meta.first).to.include(urlForPage(1));
-        expect(meta.first).to.not.include('localhost');
-        expect(meta.self).to.include(urlForPage(1));
-        expect(meta.next).to.include(urlForPage(2));
-    });
-});
+    const response = res.request.response.source
+    const meta = response.meta
+    expect(meta.first).to.include(urlForPage(1))
+    expect(meta.first).to.not.include('localhost')
+    expect(meta.self).to.include(urlForPage(1))
+    expect(meta.next).to.include(urlForPage(2))
+  })
+})
 
 describe('Should include original values of query parameters in pagination urls when Joi validation creates objects', () => {
-    const urlPrefix = 'http://localhost/query-params?';
-    const urlPrefixLen = urlPrefix.length;
-    const expectedCount = 3;
+  const urlPrefix = 'http://localhost/query-params?'
+  const urlPrefixLen = urlPrefix.length
+  const expectedCount = 3
 
-    const splitParams = (url) => {
-        expect(url).to.startWith(urlPrefix);
-        return url.substr(urlPrefixLen).split('&');
-    };
+  const splitParams = (url) => {
+    expect(url).to.startWith(urlPrefix)
+    return url.substr(urlPrefixLen).split('&')
+  }
 
-    it('Should include dates in pagination urls', async () => {
-        const dateQuery = 'testDate=1983-01-27';
+  it('Should include dates in pagination urls', async () => {
+    const dateQuery = 'testDate=1983-01-27'
 
-        const server = register();
-        await server.register(require(pluginName));
+    const server = register()
+    await server.register(require(pluginName))
 
-        const request = {
-            method: 'GET',
-            url: `/query-params?${dateQuery}&page=2&limit=1`
-        };
+    const request = {
+      method: 'GET',
+      url: `/query-params?${dateQuery}&page=2&limit=1`
+    }
 
-        const res = await server.inject(request);
-        expect(res.request.query.testDate).to.be.a.date();
-        expect(res.request.query.testDate.toISOString()).to.equal(
-            '1983-01-27T00:00:00.000Z'
-        );
+    const res = await server.inject(request)
+    expect(res.request.query.testDate).to.be.a.date()
+    expect(res.request.query.testDate.toISOString()).to.equal(
+      '1983-01-27T00:00:00.000Z'
+    )
 
-        const response = res.request.response.source;
-        expect(response.meta.count).to.equal(expectedCount);
-        expect(response.meta.pageCount).to.equal(expectedCount);
-        expect(response.meta.totalCount).to.equal(expectedCount);
-        expect(splitParams(response.meta.next)).to.include(dateQuery);
-        expect(splitParams(response.meta.previous)).to.include(dateQuery);
-        expect(splitParams(response.meta.self)).to.include(dateQuery);
-        expect(splitParams(response.meta.first)).to.include(dateQuery);
-        expect(splitParams(response.meta.last)).to.include(dateQuery);
-    });
+    const response = res.request.response.source
+    expect(response.meta.count).to.equal(expectedCount)
+    expect(response.meta.pageCount).to.equal(expectedCount)
+    expect(response.meta.totalCount).to.equal(expectedCount)
+    expect(splitParams(response.meta.next)).to.include(dateQuery)
+    expect(splitParams(response.meta.previous)).to.include(dateQuery)
+    expect(splitParams(response.meta.self)).to.include(dateQuery)
+    expect(splitParams(response.meta.first)).to.include(dateQuery)
+    expect(splitParams(response.meta.last)).to.include(dateQuery)
+  })
 
-    it('Should include arrays in pagination urls', async () => {
-        const arrayQuery = `testArray=${encodeURIComponent('[3,4]')}`;
+  it('Should include arrays in pagination urls', async () => {
+    const arrayQuery = `testArray=${encodeURIComponent('[3,4]')}`
 
-        const server = register();
-        await server.register(require(pluginName));
+    const server = register()
+    await server.register(require(pluginName))
 
-        const request = {
-            method: 'GET',
-            url: `/query-params?${arrayQuery}&page=2&limit=1`
-        };
+    const request = {
+      method: 'GET',
+      url: `/query-params?${arrayQuery}&page=2&limit=1`
+    }
 
-        const res = await server.inject(request);
-        expect(res.request.query.testArray)
-            .to.be.an.array()
-            .and.only.include([3, 4]);
+    const res = await server.inject(request)
+    expect(res.request.query.testArray)
+      .to.be.an.array()
+      .and.only.include([3, 4])
 
-        const response = res.request.response.source;
-        expect(response.meta.count).to.equal(expectedCount);
-        expect(response.meta.pageCount).to.equal(expectedCount);
-        expect(response.meta.totalCount).to.equal(expectedCount);
-        expect(splitParams(response.meta.next)).to.include(arrayQuery);
-        expect(splitParams(response.meta.previous)).to.include(arrayQuery);
-        expect(splitParams(response.meta.self)).to.include(arrayQuery);
-        expect(splitParams(response.meta.first)).to.include(arrayQuery);
-        expect(splitParams(response.meta.last)).to.include(arrayQuery);
-    });
+    const response = res.request.response.source
+    expect(response.meta.count).to.equal(expectedCount)
+    expect(response.meta.pageCount).to.equal(expectedCount)
+    expect(response.meta.totalCount).to.equal(expectedCount)
+    expect(splitParams(response.meta.next)).to.include(arrayQuery)
+    expect(splitParams(response.meta.previous)).to.include(arrayQuery)
+    expect(splitParams(response.meta.self)).to.include(arrayQuery)
+    expect(splitParams(response.meta.first)).to.include(arrayQuery)
+    expect(splitParams(response.meta.last)).to.include(arrayQuery)
+  })
 
-    it('Should include objects in pagination urls', async () => {
-        const objectQuery = `testObject=${encodeURIComponent(
-            JSON.stringify({ a: 1, b: 2 })
-        )}`;
+  it('Should include objects in pagination urls', async () => {
+    const objectQuery = `testObject=${encodeURIComponent(
+      JSON.stringify({ a: 1, b: 2 })
+    )}`
 
-        const server = register();
-        await server.register(require(pluginName));
+    const server = register()
+    await server.register(require(pluginName))
 
-        const request = {
-            method: 'GET',
-            url: `/query-params?${objectQuery}&page=2&limit=1`
-        };
+    const request = {
+      method: 'GET',
+      url: `/query-params?${objectQuery}&page=2&limit=1`
+    }
 
-        const res = await server.inject(request);
-        expect(res.request.query.testObject)
-            .to.be.an.object()
-            .and.only.include({ a: 1, b: 2 });
+    const res = await server.inject(request)
+    expect(res.request.query.testObject)
+      .to.be.an.object()
+      .and.only.include({ a: 1, b: 2 })
 
-        const response = res.request.response.source;
-        expect(response.meta.count).to.equal(expectedCount);
-        expect(response.meta.pageCount).to.equal(expectedCount);
-        expect(response.meta.totalCount).to.equal(expectedCount);
-        expect(splitParams(response.meta.next)).to.include(objectQuery);
-        expect(splitParams(response.meta.previous)).to.include(objectQuery);
-        expect(splitParams(response.meta.self)).to.include(objectQuery);
-        expect(splitParams(response.meta.first)).to.include(objectQuery);
-        expect(splitParams(response.meta.last)).to.include(objectQuery);
-    });
-});
+    const response = res.request.response.source
+    expect(response.meta.count).to.equal(expectedCount)
+    expect(response.meta.pageCount).to.equal(expectedCount)
+    expect(response.meta.totalCount).to.equal(expectedCount)
+    expect(splitParams(response.meta.next)).to.include(objectQuery)
+    expect(splitParams(response.meta.previous)).to.include(objectQuery)
+    expect(splitParams(response.meta.self)).to.include(objectQuery)
+    expect(splitParams(response.meta.first)).to.include(objectQuery)
+    expect(splitParams(response.meta.last)).to.include(objectQuery)
+  })
+})
 
 describe('Include custom headers', () => {
-    it('Should include any custom-header set in the pre-processed response', async () => {
-        const server = register();
-        await server.register(require(pluginName));
+  it('Should include any custom-header set in the pre-processed response', async () => {
+    const server = register()
+    await server.register(require(pluginName))
 
-        const request = {
-            method: 'GET',
-            url: `/custom-header`
-        };
+    const request = {
+      method: 'GET',
+      url: `/custom-header`
+    }
 
-        const customHeaderName = 'custom-header';
-        const customHeaderValue = 'pizza';
-        const expectedCount = 3;
-        const expectedPageCount = 1;
+    const customHeaderName = 'custom-header'
+    const customHeaderValue = 'pizza'
+    const expectedCount = 3
+    const expectedPageCount = 1
 
-        const res = await server.inject(request);
-        expect(res.request.response.headers[customHeaderName]).to.equal(
-            customHeaderValue
-        );
+    const res = await server.inject(request)
+    expect(res.request.response.headers[customHeaderName]).to.equal(
+      customHeaderValue
+    )
 
-        const response = res.request.response.source;
-        expect(response.meta.count).to.equal(expectedCount);
-        expect(response.meta.pageCount).to.equal(expectedPageCount);
-        expect(response.meta.totalCount).to.equal(expectedCount);
-    });
-});
+    const response = res.request.response.source
+    expect(response.meta.count).to.equal(expectedCount)
+    expect(response.meta.pageCount).to.equal(expectedPageCount)
+    expect(response.meta.totalCount).to.equal(expectedCount)
+  })
+})

--- a/test/test.js
+++ b/test/test.js
@@ -1418,6 +1418,7 @@ describe('Test /users route', () => {
         expect(meta.next).to.be.null();
         expect(meta.first).to.equal('http://localhost/users?page=1&limit=5');
         expect(meta.last).to.equal('http://localhost/users?page=4&limit=5');
+        expect(meta.self).to.equal('http://localhost/users?page=4&limit=5');
     });
 
     it('Test that hasNext, related links behave correctly with zero index', async () => {
@@ -1447,6 +1448,7 @@ describe('Test /users route', () => {
         expect(meta.next).to.be.null();
         expect(meta.first).to.equal('http://localhost/users?page=0&limit=5');
         expect(meta.last).to.equal('http://localhost/users?page=3&limit=5');
+        expect(meta.self).to.equal('http://localhost/users?page=3&limit=5');
     });
 
     it('Test that hasPrev, related links behave correctly', async () => {
@@ -1475,6 +1477,7 @@ describe('Test /users route', () => {
         expect(meta.previous).to.be.null();
         expect(meta.first).to.equal('http://localhost/users?page=1&limit=5');
         expect(meta.last).to.equal('http://localhost/users?page=4&limit=5');
+        expect(meta.self).to.equal('http://localhost/users?page=1&limit=5');
     });
 
     it('Test that hasPrev, related links behave correctly with zero index', async () => {
@@ -1504,6 +1507,7 @@ describe('Test /users route', () => {
         expect(meta.previous).to.equal(null);
         expect(meta.first).to.equal('http://localhost/users?page=0&limit=5');
         expect(meta.last).to.equal('http://localhost/users?page=3&limit=5');
+        expect(meta.self).to.equal('http://localhost/users?page=0&limit=5');
     });
 });
 


### PR DESCRIPTION
Allow for starting pagination at zero instead of one
* Fix-up some of the code to use ES6 conventions
* Adds a `.prettierrc.json` configuration - I attempted to mirror the original style as best as possible here
* Defaults to the original "1" index for pages
* Top-level configuration option for using "0" index for pages
* Adds unit tests to cover link functionality