### PR TITLE
Make hapi v19 a peer rather than a direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -128,6 +128,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.1.tgz",
       "integrity": "sha512-fMr4d7zLzsAXo28PRRQPXR1o2Wmu+6z+VY1UzDp0iFo13Twj8WePakwXBiqn3E1aAlTpSNzCXdnnQXFhst8h8Q==",
+      "dev": true,
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/hoek": "9.x.x"
@@ -145,6 +146,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
       "integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
+      "dev": true,
       "requires": {
         "@hapi/hoek": "9.x.x"
       }
@@ -153,6 +155,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
       "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
+      "dev": true,
       "requires": {
         "@hapi/hoek": "9.x.x"
       }
@@ -180,6 +183,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
       "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
+      "dev": true,
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/hoek": "9.x.x"
@@ -188,12 +192,14 @@
     "@hapi/bourne": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
-      "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
+      "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==",
+      "dev": true
     },
     "@hapi/call": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.0.tgz",
       "integrity": "sha512-4xHIWWqaIDQlVU88XAnomACSoC7iWUfaLfdu2T7I0y+HFFwZUrKKGfwn6ik4kwKsJRMnOliG3UXsF8V/94+Lkg==",
+      "dev": true,
       "requires": {
         "@hapi/address": "4.x.x",
         "@hapi/boom": "9.x.x",
@@ -204,6 +210,7 @@
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.0.tgz",
       "integrity": "sha512-FDEjfn26RZRyOEPeZdaAL7dRiAK5FOGuwTnTw0gxK30csAlKeOHsEnoIxnLIXx7QOS17eUaOk6+MiweWQM6Keg==",
+      "dev": true,
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/hoek": "9.x.x",
@@ -215,6 +222,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.0.tgz",
       "integrity": "sha512-ByuxVJPHNaXwLzbBv4GdTr6ccpe1nG+AfYt+8ftDWEJY7EWBWzD+Klhy5oPTDGzU26pNUh1e7fcYI1ILZRxAXQ==",
+      "dev": true,
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/hoek": "9.x.x"
@@ -233,6 +241,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
       "integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
+      "dev": true,
       "requires": {
         "@hapi/boom": "9.x.x"
       }
@@ -241,6 +250,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.0.0.tgz",
       "integrity": "sha512-Yq43ti9N51Z7jbm0Q7YVCcofA+4Gh5wsBX/jZ++Z+FM8GYfBQ1WmI9ufZSL+BVX8vRxzDkdQ2fKoG6cxOQlnVQ==",
+      "dev": true,
       "requires": {
         "@hapi/boom": "9.x.x"
       }
@@ -267,7 +277,8 @@
     "@hapi/file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
-      "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ=="
+      "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ==",
+      "dev": true
     },
     "@hapi/formula": {
       "version": "2.0.0",
@@ -278,6 +289,7 @@
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-19.1.1.tgz",
       "integrity": "sha512-rpQzSs0XsHSF7usM4qdJJ0Bcmhs9stWhUW3OiamW33bw4qL8q3uEgUKB9KH8ODmluCAkkXOQ0X0Dh9t94E5VIw==",
+      "dev": true,
       "requires": {
         "@hapi/accept": "^5.0.1",
         "@hapi/ammo": "^5.0.1",
@@ -303,6 +315,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.0.tgz",
       "integrity": "sha512-n/nheUG6zNleWkjY+3fzV3VJIAumUCaa/WoTmurjqlYY5JgC5ZKOpvP7tWi8rXmKZhbcXgjH3fHFoM55LoBT7g==",
+      "dev": true,
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/hoek": "9.x.x",
@@ -318,6 +331,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
       "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
+      "dev": true,
       "requires": {
         "@hapi/b64": "5.x.x",
         "@hapi/boom": "9.x.x",
@@ -366,6 +380,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-5.0.0.tgz",
       "integrity": "sha512-EVS6wJYeE73InTlPWt+2e3Izn319iIvffDreci3qDNT+t3lA5ylJ0/SoTaID8e0TPNUkHUSsgJZXEmLHvoYzrA==",
+      "dev": true,
       "requires": {
         "@hapi/hoek": "9.x.x",
         "mime-db": "1.x.x"
@@ -375,6 +390,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.0.tgz",
       "integrity": "sha512-Bqs1pjcDnDQo/XGoiCCNHWTFcMzPbz3L4KU04njeFQMzzEmsojMRX7TX+PezQYCMKtHJOtMg0bHxZyMGqYtbSA==",
+      "dev": true,
       "requires": {
         "@hapi/hoek": "9.x.x",
         "@hapi/vise": "4.x.x"
@@ -384,6 +400,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.2.tgz",
       "integrity": "sha512-jr1lAm8mE7J2IBxvDIuDI1qy2aAsoaD2jxOUd/7JRg/Vmrzco8HdKhtz4fKk6KHU6zbbsAp5m5aSWWVTUrag7g==",
+      "dev": true,
       "requires": {
         "@hapi/b64": "5.x.x",
         "@hapi/boom": "9.x.x",
@@ -401,6 +418,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.0.tgz",
       "integrity": "sha512-k/n0McAu8PvonfQRLyKKUvvdb+Gh/O5iAeIwv535Hpxw9B1qZcrYdZyWtHZ8O5PkA9/b/Kk+BdvtgcxeKMB/2g==",
+      "dev": true,
       "requires": {
         "@hapi/hoek": "9.x.x",
         "@hapi/joi": "17.x.x",
@@ -441,6 +459,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.0.tgz",
       "integrity": "sha512-JXddnJkRh3Xhv9lY1tA+TSIUaoODKbdNIPL/M8WFvFQKOttmGaDeqTW5e8Gf01LtLI7L5DraLMULHjrK1+YNFg==",
+      "dev": true,
       "requires": {
         "@hapi/hoek": "9.x.x",
         "@hapi/joi": "17.x.x"
@@ -450,6 +469,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.0.tgz",
       "integrity": "sha512-Upw/kmKotC9iEmK4y047HMYe4LDKsE5NWfjgX41XNKmFvxsQL7OiaCWVhuyyhU0ShDGBfIAnCH8jZr49z/JzZA==",
+      "dev": true,
       "requires": {
         "@hapi/bounce": "2.x.x",
         "@hapi/hoek": "9.x.x"
@@ -459,6 +479,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.2.tgz",
       "integrity": "sha512-+0VNxysQu+UYzkfvAXq3X4aN65TnUwiR7gsq2cQ/4Rq26nCJjHAfrkYReEeshU2hPmJ3m5QuaBzyDqRm8WOpyg==",
+      "dev": true,
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/bounce": "2.x.x",
@@ -473,6 +494,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.3.tgz",
       "integrity": "sha512-CekDizZkDGERJ01C0+TzHlKtqdXZxzSWTOaH6THBrbOHnsr3GY+yiMZC+AfNCypfE17RaIakGIAbpL2Tk1z2+A==",
+      "dev": true,
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/bourne": "2.x.x",
@@ -486,7 +508,8 @@
     "@hapi/teamwork": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-4.0.0.tgz",
-      "integrity": "sha512-V6xYOrr5aFv/IJqNPneaYCu8vuGTKisamqHVRS3JJnbZr18TrpXdsJOYk9pjPhFti+M2YETPebQLUr820N5NoQ=="
+      "integrity": "sha512-V6xYOrr5aFv/IJqNPneaYCu8vuGTKisamqHVRS3JJnbZr18TrpXdsJOYk9pjPhFti+M2YETPebQLUr820N5NoQ==",
+      "dev": true
     },
     "@hapi/topo": {
       "version": "5.0.0",
@@ -500,6 +523,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
       "integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
+      "dev": true,
       "requires": {
         "@hapi/hoek": "9.x.x"
       }
@@ -508,6 +532,7 @@
       "version": "17.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.0.0.tgz",
       "integrity": "sha512-d8lqCinbKyDByn7GzJDRDbitddhIEydNm44UcAMejfhEH3o4IYvKYq6K8cAqXbilXPuvZc0ErlUOg9SDdgRtMw==",
+      "dev": true,
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/bourne": "2.x.x",
@@ -1612,7 +1637,8 @@
     "mime-db": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.27",

--- a/package.json
+++ b/package.json
@@ -20,13 +20,16 @@
   },
   "dependencies": {
     "@hapi/boom": "^9.1.0",
-    "@hapi/hapi": "^19.1.1",
     "@hapi/hoek": "^9.0.4",
     "@hapi/joi": "^17.1.1"
+  },
+  "peerDependencies": {
+    "@hapi/hapi": "^19.0.0"
   },
   "devDependencies": {
     "@hapi/bourne": "^2.0.0",
     "@hapi/code": "^8.0.1",
+    "@hapi/hapi": "^19.1.1",
     "@hapi/lab": "^22.0.4",
     "coveralls": "^3.0.5"
   }


### PR DESCRIPTION
I recommend making hapi 19 a peer rather than a direct dependency, as it's more flexible for consumers and I believe has no effect of this module.

If hapi v20 comes out and this plugin isn't broken, then this plugin would just require an update to the peer dependency version to include both v19 and v20, and hapi-pagination could publish a new minor version rather than a major version.  And before that is complete, folks would still be able to upgrade their version of hapi if they can live with the peer dependency warning from npm.  Using a peer dependency would also avoid unneeded duplicate installs of hapi in case there is an incidental version conflict (e.g. if I need to run 19.0.0 in my project but this plugin lists a dependency on 19.1.1+).

I know v4 isn't published yet, so I figured now might be a good time to offer this!