### PR TITLE
Fix last link value issue when result is empty

### DIFF
--- a/lib/ext.js
+++ b/lib/ext.js
@@ -180,6 +180,8 @@ module.exports = class Ext {
 
     const maxPage = zeroIndex ? pageCount - 1 : pageCount
     const meta = {}
+    const hasLast =
+      !Utils.isNil(totalCount) && totalCount !== 0
     const hasNext =
       !Utils.isNil(totalCount) && totalCount !== 0 && currentPage < maxPage
     const hasPrevious =
@@ -253,7 +255,7 @@ module.exports = class Ext {
       this.assignIfActive(
         meta,
         'last',
-        getUri(!zeroIndex ? pageCount : pageCount - 1)
+        hasLast ? getUri(!zeroIndex ? pageCount : pageCount - 1) : null
       )
 
       const newSource = {

--- a/test/test.js
+++ b/test/test.js
@@ -2180,6 +2180,23 @@ describe('Empty result set', () => {
     expect(response.statusCode).to.be.greaterThan(199)
     expect(response.statusCode).to.be.lessThan(300)
   })
+
+  it('Last, next, and previous links should be null', async () => {
+    const server = register()
+    await server.register(require(pluginName))
+
+    const request = {
+      method: 'GET',
+      url: '/empty'
+    }
+
+    const res = await server.inject(request)
+
+    const response = res.request.response.source
+    expect(response.meta.last).to.be.null()
+    expect(response.meta.next).to.be.null()
+    expect(response.meta.previous).to.be.null()
+  })
 })
 
 describe('Exception', () => {


### PR DESCRIPTION
Fixed the issue #88 that `last` link incorrectly populated when result is empty and added a unit test for it.