### PR TITLE
update hapi peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@hapi/joi": "^17.1.1"
   },
   "peerDependencies": {
-    "@hapi/hapi": "^19.0.0"
+    "@hapi/hapi": "^19.0.0 || ^20.0.0"
   },
   "devDependencies": {
     "@hapi/bourne": "^2.0.0",


### PR DESCRIPTION
This PR updates `package.json` to allow the usage of this plugin with Hapi 19 and 20 (which does not have breaking changes)